### PR TITLE
Add meta tag for charset utf8 to templates

### DIFF
--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>{{resource_name}} API</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="{{url_prefix}}/assets/stylesheets/bootstrap.css"/>
     <link rel="stylesheet" href="{{url_prefix}}/assets/stylesheets/codemirror.css"/>
     <link rel="stylesheet" href="{{url_prefix}}/assets/stylesheets/application.css"/>

--- a/templates/rspec_api_documentation/html_index.mustache
+++ b/templates/rspec_api_documentation/html_index.mustache
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>{{ api_name }}</title>
+  <meta charset="utf-8">
   <link rel="stylesheet" href="{{ url_prefix }}/assets/stylesheets/bootstrap.css"/>
 </head>
 <body>

--- a/templates/rspec_api_documentation/wurl_example.mustache
+++ b/templates/rspec_api_documentation/wurl_example.mustache
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <head>
   <title>{{resource_name}} API</title>
+  <meta charset="utf-8">
   <link rel="stylesheet" href="{{url_prefix}}/assets/stylesheets/bootstrap.css"/>
   <link rel="stylesheet" href="{{url_prefix}}/assets/stylesheets/codemirror.css"/>
   <link rel="stylesheet" href="{{url_prefix}}/assets/stylesheets/application.css"/>

--- a/templates/rspec_api_documentation/wurl_index.mustache
+++ b/templates/rspec_api_documentation/wurl_index.mustache
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>{{ api_name }}</title>
+  <meta charset="utf-8">
   <link rel="stylesheet" href="{{ url_prefix }}/assets/stylesheets/bootstrap.css"/>
 </head>
 <body>


### PR DESCRIPTION
Template HTML not have meta tag for utf8.
