### PR TITLE
Support multibyte description

### DIFF
--- a/lib/rspec_api_documentation/html_writer.rb
+++ b/lib/rspec_api_documentation/html_writer.rb
@@ -73,7 +73,7 @@ module RspecApiDocumentation
 
     def filename
       basename = description.downcase.gsub(/\s+/, '_').gsub(/[^a-z_]/, '')
-      basename = URI.encode(description) if basename.blank?
+      basename = Digest::MD5.new.update(description).to_s if basename.blank?
       "#{basename}.html"
     end
 

--- a/spec/html_writer_spec.rb
+++ b/spec/html_writer_spec.rb
@@ -49,7 +49,8 @@ describe RspecApiDocumentation::HtmlExample do
     let(:example) { group.example(label) {} }
 
     it "should have downcased filename" do
-      html_example.filename.should == URI.encode(label) + ".html"
+      filename = Digest::MD5.new.update(label).to_s
+      html_example.filename.should == filename + ".html"
     end
   end
 end


### PR DESCRIPTION
Example filename is empty when description is multibyte string.
