### PR TITLE
Fix for do_request and extra parameters containing path params and query string params

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -39,7 +39,7 @@ module RspecApiDocumentation::DSL
       path_or_query = path
 
       if method == :get && !query_string.blank?
-        path_or_query = path + "?#{query_string}"
+        path_or_query += "?#{query_string}"
       else
         params_or_body = respond_to?(:raw_post) ? raw_post : params
       end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -181,6 +181,17 @@ resource "Order" do
     end
   end
 
+  get "/orders/:order_id/line_items/:id" do
+    parameter :type, "The type document you want"
+
+    describe "do_request" do
+      it "should correctly set path variables and other parameters" do
+        client.should_receive(method).with("/orders/3/line_items/2?type=short", nil, nil)
+        do_request(:id => 2, :order_id => 3, :type => 'short')
+      end
+    end
+  end
+
   get "/orders/:order_id" do
     let(:order) { stub(:id => 1) }
 


### PR DESCRIPTION
When dealing with path like `/items_a/:items_a_id/items_b/:id` and using do_request with `:items_a_id`, `:id` and `:an_extra_param`, do_request calls `path` 2 times: 
- first to set `path_or_query`, 
- second to set path in case of :get method. 

But call to path, deletes `:items_a_id` and `:id` from extra_params hash. So at the end, path is equal to `/items_a/:items_a_id/items_b/:id?an_extra_param=`
