### PR TITLE
Fix curl escape

### DIFF
--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -40,7 +40,7 @@ module RspecApiDocumentation
     end
 
     def post_data
-      escaped_data = data.gsub("'", "\\u0027")
+      escaped_data = data.to_s.gsub("'", "\\u0027")
       "-d '#{escaped_data}'"
     end
 

--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -13,7 +13,7 @@ describe RspecApiDocumentation::Curl do
 
     it { should =~ /^curl/ }
     it { should =~ /http:\/\/example\.com\/orders/ }
-    it { should =~ /-d "order%5Bsize%5D=large&order%5Btype%5D=cart"/ }
+    it { should =~ /-d 'order%5Bsize%5D=large&order%5Btype%5D=cart'/ }
     it { should =~ /-X POST/ }
     it { should =~ /-H "Accept: application\/json"/ }
     it { should =~ /-H "X-Header: header"/ }
@@ -50,7 +50,7 @@ describe RspecApiDocumentation::Curl do
 
     it { should =~ /^curl/ }
     it { should =~ /http:\/\/example\.com\/orders\/1/ }
-    it { should =~ /-d "size=large"/ }
+    it { should =~ /-d 'size=large'/ }
     it { should =~ /-X PUT/ }
     it { should =~ /-H "Accept: application\/json"/ }
     it { should =~ /-H "X-Header: header"/ }


### PR DESCRIPTION
Fixes https://github.com/zipmark/rspec_api_documentation/issues/58
Using single quotes since JSON uses double quotes, the output is a bit nicer this way.
