### PR TITLE
Allow parameters without values

### DIFF
--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -70,7 +70,7 @@ module RspecApiDocumentation
       strings = query_string.split("&")
       arrays = strings.map do |segment|
         k,v = segment.split("=")
-        [k, CGI.unescape(v)]
+        [k, v && CGI.unescape(v)]
       end
       Hash[arrays]
     end

--- a/spec/rack_test_client_spec.rb
+++ b/spec/rack_test_client_spec.rb
@@ -80,6 +80,19 @@ describe RspecApiDocumentation::RackTestClient do
     end
   end
 
+  context "when doing request without parameter value" do
+    before do
+      test_client.post "/greet?query=&other=exists"
+    end
+
+    context "when examples should be documented", :document => true do
+      it "should still argument the metadata" do
+        metadata = example.metadata[:requests].first
+        metadata[:request_query_parameters].should == {'query' => nil, 'other' => 'exists'}
+      end
+    end
+  end
+
   context "after a request is made" do
     before do
       test_client.post "/greet?query=test+query", post_data, headers


### PR DESCRIPTION
Hi!
I found an issue when my docs were sending `"&param="`. It tried to unescape the nil value and failed with exception.
So this patch fixes the issue and adds a test.
Hope thats all right!
