### PR TITLE
Remove ExampleGroup autoload

### DIFF
--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -14,7 +14,6 @@ module RspecApiDocumentation
     autoload :ApiDocumentation
     autoload :ApiFormatter
     autoload :Example
-    autoload :ExampleGroup
     autoload :Index
     autoload :ClientBase
     autoload :Headers


### PR DESCRIPTION
class doesn't exist.  breaks in latest Rails 3 release.
