### PR TITLE
Allow requests with extra_params and no parameters

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -52,8 +52,7 @@ module RspecApiDocumentation::DSL
     end
 
     def params
-      return unless example.metadata[:parameters]
-      parameters = example.metadata[:parameters].inject({}) do |hash, param|
+      parameters = example.metadata.fetch(:parameters, {}).inject({}) do |hash, param|
         set_param(hash, param)
       end
       parameters.merge!(extra_params)

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -357,6 +357,18 @@ resource "Order" do
     end
   end
 
+  context "request with only extra params" do
+    post "/orders" do
+      context "extra options for do_request" do
+        before do
+          client.should_receive(:post).with("/orders", {"order_type" => "big"}, nil)
+        end
+
+        example_request "should take an optional parameter hash", :order_type => "big"
+      end
+    end
+  end
+
   context "last_response helpers" do
     put "/orders" do
       it "status" do


### PR DESCRIPTION
Without this commit, the following request:

```
put '/concerts/1' do
  example_request 'Update an existing concert', concert: {year: 2011} do
     ...
  end
end
```

would receive **no** PUT body/params, rather than the specified `concert: {year: 2011}`.

The reason is that the function `params` was returning nil if `example.metadata[:parameters]` was undefined, and the only one to define `example.metadata[:parameters]` was to have previously called `parameter`. 

In other words, requests were not allowed to have so-called "extra parameters" unless they had at least one "parameter" specified.

This commit removes this restrictions, allowing requests to specify all their parameters "inline".
