### PR TITLE
Fix HTML links generated by special resource names

### DIFF
--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -18,7 +18,7 @@ module RspecApiDocumentation
       end
 
       def dirname
-        resource_name.downcase.gsub(/\s+/, '_')
+        resource_name.downcase.gsub(/[^0-9A-Za-z.\-]+/, '_')
       end
       
       def filename


### PR DESCRIPTION
This commit ensures that the links from the `index` page to the
`examples` pages of the generated HTML documentation are not broken
when the resource name includes special characters like `:`.

I'm aware this pull request needs **tests** to be accepted; however I was not sure _how_ to write the required tests. 
I will explain how to reproduce the bug solved by this PR here and hopefully get some feedback on how to write the test (and update this PR accordingly):
1. chdir to `example`
2. edit `spec/acceptance/orders_spec.rb`, changing `resource "Orders"` to `resource "Super::Orders"`
3. run `rake docs:generate`
4. open `doc/api/index.html` in the browser
5. click on any example link, for instance `Creating an order`
6. The link will wrongly point to `super::orders/creating_an_order.html`, that is, it will interpret `super` as the URL protocol, rather than linking to an HTML file in a subfolder

My commit replaces any non-ASCII character with an underscore, which generates filesystem-acceptable filenames
