### PR TITLE
All writers now inherit from a base writer

### DIFF
--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -28,12 +28,14 @@ module RspecApiDocumentation
   module Writers
     extend ActiveSupport::Autoload
 
+    autoload :Writer
     autoload :GeneralMarkupWriter
     autoload :HtmlWriter
     autoload :TextileWriter
     autoload :JsonWriter
+    autoload :AppendJsonWriter
     autoload :JsonIodocsWriter
-    autoload :IndexWriter
+    autoload :IndexHelper
     autoload :CombinedTextWriter
     autoload :CombinedJsonWriter
   end

--- a/lib/rspec_api_documentation/api_documentation.rb
+++ b/lib/rspec_api_documentation/api_documentation.rb
@@ -10,10 +10,9 @@ module RspecApiDocumentation
     end
 
     def clear_docs
-      if File.exists?(docs_dir)
-        FileUtils.rm_rf(docs_dir, :secure => true)
+      writers.each do |writer|
+        writer.clear_docs(docs_dir)
       end
-      FileUtils.mkdir_p(docs_dir)
     end
 
     def document_example(rspec_example)

--- a/lib/rspec_api_documentation/views/markup_index.rb
+++ b/lib/rspec_api_documentation/views/markup_index.rb
@@ -14,7 +14,7 @@ module RspecApiDocumentation
       end
 
       def sections
-        RspecApiDocumentation::Writers::IndexWriter.sections(examples, @configuration)
+        RspecApiDocumentation::Writers::IndexHelper.sections(examples, @configuration)
       end
     end
   end

--- a/lib/rspec_api_documentation/writers/append_json_writer.rb
+++ b/lib/rspec_api_documentation/writers/append_json_writer.rb
@@ -1,0 +1,49 @@
+require 'rspec_api_documentation/writers/formatter'
+
+module RspecApiDocumentation
+  module Writers
+    class AppendJsonWriter < JsonWriter
+      def write
+        index_file = docs_dir.join("index.json")
+        if File.exists?(index_file) && (output = File.read(index_file)).length >= 2
+          existing_index_hash = JSON.parse(output)
+        end
+        File.open(index_file, "w+") do |f|
+          f.write Formatter.to_json(AppendJsonIndex.new(index, configuration, existing_index_hash))
+        end
+        write_examples
+      end
+
+      def self.clear_docs(docs_dir)
+        nil #noop
+      end
+    end
+
+    class AppendJsonIndex < JsonIndex
+      def initialize(index, configuration, existing_index_hash = nil)
+        @index = index
+        @configuration = configuration
+        @existing_index_hash = clean_index_hash(existing_index_hash)
+      end
+
+      def as_json(opts = nil)
+        sections.inject(@existing_index_hash) do |h, section|
+          h[:resources].push(section_hash(section))
+          h
+        end
+      end
+
+      def clean_index_hash(existing_index_hash)
+        unless existing_index_hash.is_a?(Hash) && existing_index_hash["resources"].is_a?(Array) #check format
+          existing_index_hash = {:resources => []}
+        end
+        existing_index_hash = existing_index_hash.deep_symbolize_keys
+        existing_index_hash[:resources].map!(&:deep_symbolize_keys).reject! do |resource|
+          resource_names = sections.map{|s| s[:resource_name]}
+          resource_names.include? resource[:name]
+        end
+        existing_index_hash
+      end
+    end
+  end
+end

--- a/lib/rspec_api_documentation/writers/combined_json_writer.rb
+++ b/lib/rspec_api_documentation/writers/combined_json_writer.rb
@@ -2,7 +2,7 @@ require 'rspec_api_documentation/writers/json_writer'
 
 module RspecApiDocumentation
   module Writers
-    class CombinedJsonWriter
+    class CombinedJsonWriter < Writer
       def self.write(index, configuration)
         File.open(configuration.docs_dir.join("combined.json"), "w+") do |f|
           examples = []

--- a/lib/rspec_api_documentation/writers/combined_text_writer.rb
+++ b/lib/rspec_api_documentation/writers/combined_text_writer.rb
@@ -1,6 +1,6 @@
 module RspecApiDocumentation
   module Writers
-    class CombinedTextWriter
+    class CombinedTextWriter < Writer
       def self.write(index, configuration)
         index.examples.each do |rspec_example|
           example = CombinedTextExample.new(rspec_example)

--- a/lib/rspec_api_documentation/writers/general_markup_writer.rb
+++ b/lib/rspec_api_documentation/writers/general_markup_writer.rb
@@ -1,20 +1,8 @@
 module RspecApiDocumentation
   module Writers
-    class GeneralMarkupWriter
-      attr_accessor :index, :configuration
-
+    class GeneralMarkupWriter < Writer
       INDEX_FILE_NAME = 'index'
-      
-      def initialize(index, configuration)
-        self.index = index
-        self.configuration = configuration
-      end
 
-      def self.write(index, configuration)
-        writer = new(index, configuration)
-        writer.write
-      end
-      
       def write
         File.open(configuration.docs_dir.join(index_file_name + '.' + extension), "w+") do |f|
           f.write markup_index_class.new(index, configuration).render

--- a/lib/rspec_api_documentation/writers/html_writer.rb
+++ b/lib/rspec_api_documentation/writers/html_writer.rb
@@ -1,8 +1,6 @@
 module RspecApiDocumentation
   module Writers
     class HtmlWriter < GeneralMarkupWriter
-      attr_accessor :index, :configuration
-
       EXTENSION = 'html'
 
       def markup_index_class

--- a/lib/rspec_api_documentation/writers/index_helper.rb
+++ b/lib/rspec_api_documentation/writers/index_helper.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/enumerable"
 
 module RspecApiDocumentation
   module Writers
-    module IndexWriter
+    module IndexHelper
       def sections(examples, configuration)
         resources = examples.group_by(&:resource_name).inject([]) do |arr, (resource_name, examples)|
           ordered_examples = configuration.keep_source_order ? examples : examples.sort_by(&:description)

--- a/lib/rspec_api_documentation/writers/json_iodocs_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_iodocs_writer.rb
@@ -2,19 +2,13 @@ require 'rspec_api_documentation/writers/formatter'
 
 module RspecApiDocumentation
   module Writers
-    class JsonIodocsWriter
-      attr_accessor :index, :configuration, :api_key
+    class JsonIodocsWriter < Writer
+      attr_accessor :api_key
       delegate :docs_dir, :to => :configuration
 
       def initialize(index, configuration)
-        self.index = index
-        self.configuration = configuration
+        super
         self.api_key = configuration.api_name.parameterize
-      end
-
-      def self.write(index, configuration)
-        writer = new(index, configuration)
-        writer.write
       end
 
       def write
@@ -34,7 +28,7 @@ module RspecApiDocumentation
       end
 
       def sections
-        IndexWriter.sections(examples, @configuration)
+        IndexHelper.sections(examples, @configuration)
       end
 
       def examples

--- a/lib/rspec_api_documentation/writers/textile_writer.rb
+++ b/lib/rspec_api_documentation/writers/textile_writer.rb
@@ -1,8 +1,6 @@
 module RspecApiDocumentation
   module Writers
     class TextileWriter < GeneralMarkupWriter
-      attr_accessor :index, :configuration
-
       EXTENSION = 'textile'
 
       def markup_index_class

--- a/lib/rspec_api_documentation/writers/writer.rb
+++ b/lib/rspec_api_documentation/writers/writer.rb
@@ -1,0 +1,25 @@
+module RspecApiDocumentation
+  module Writers
+    class Writer
+      attr_accessor :index, :configuration
+      
+      def initialize(index, configuration)
+        self.index = index
+        self.configuration = configuration
+      end
+
+      def self.write(index, configuration)
+        writer = new(index, configuration)
+        writer.write
+      end
+      
+      def self.clear_docs(docs_dir)
+        if File.exists?(docs_dir)
+          FileUtils.rm_rf(docs_dir, :secure => true)
+        end
+        FileUtils.mkdir_p(docs_dir)
+      end
+    end
+  end
+end
+

--- a/spec/writers/index_writer_spec.rb
+++ b/spec/writers/index_writer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RspecApiDocumentation::Writers::IndexWriter do
+describe RspecApiDocumentation::Writers::IndexHelper do
   describe "#sections" do
     let(:example_1) { double(:resource_name => "Order", :description => "Updating an order") }
     let(:example_2) { double(:resource_name => "Order", :description => "Creating an order") }
@@ -9,7 +9,7 @@ describe RspecApiDocumentation::Writers::IndexWriter do
 
     context "with default value for keep_source_order" do
       let(:configuration) { RspecApiDocumentation::Configuration.new }
-      subject { RspecApiDocumentation::Writers::IndexWriter.sections(examples, configuration) }
+      subject { RspecApiDocumentation::Writers::IndexHelper.sections(examples, configuration) }
 
       it "should order resources by resource name" do
         subject.map { |resource| resource[:resource_name] }.should == ["Cart", "Order"]
@@ -21,7 +21,7 @@ describe RspecApiDocumentation::Writers::IndexWriter do
     end
 
     context "with keep_source_order set to true" do
-      subject { RspecApiDocumentation::Writers::IndexWriter.sections(examples, double(:keep_source_order => true)) }
+      subject { RspecApiDocumentation::Writers::IndexHelper.sections(examples, double(:keep_source_order => true)) }
 
       it "should order resources by source code declaration" do
         subject.map { |resource| resource[:resource_name] }.should == ["Order", "Cart"]


### PR DESCRIPTION
- the writers are now responsible for cleaning docs
- added an append_json writer that does not delete docs and simply modifies index.json
## Example of use

in lib/tasks/my_docs.rspec:

``` ruby
RSpec::Core::RakeTask.new('mydocs:generate', :spec_file) do |t, task_args|
  if spec_file = task_args[:spec_file]
    ENV["DOC_FORMAT"] = "append_json"
  end
  t.pattern    = spec_file || 'spec/acceptance/**/*_spec.rb'
  t.rspec_opts = ["--format RspecApiDocumentation::ApiFormatter"]
end
```

in spec/support/documentation.rb

``` ruby
ENV["DOC_FORMAT"] ||= "json"

RspecApiDocumentation.configure do |config|
  config.format    = ENV["DOC_FORMAT"]
end
```

then when I run `rake mydocs:generate[spec/acceptance/foo_spec.rb]`, I only generate output relevant to foo.
