### PR TITLE
Allow documenting multipart/form-data submissions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (>= 3.0.0)
       i18n (>= 0.1.0)
       json (>= 1.4.6)
+      multipart-parser
       mustache (>= 0.99.4)
       rspec (>= 2.14.0)
 
@@ -54,6 +55,7 @@ GEM
     minitest (4.7.5)
     multi_json (1.8.2)
     multi_test (0.0.2)
+    multipart-parser (0.1.1)
     mustache (0.99.5)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)

--- a/lib/rspec_api_documentation/example.rb
+++ b/lib/rspec_api_documentation/example.rb
@@ -45,7 +45,7 @@ module RspecApiDocumentation
     def requests
       reqs = metadata[:requests] || []
       reqs.each do |req|
-        if req[:request_headers]["Content-Type"].match /\Amultipart\/form-data/
+        if req[:request_headers]["Content-Type"].try(:match, /\Amultipart\/form-data/)
           i = req[:request_body].index /^Content-Disposition: form-data.* filename=\"/
           i = req[:request_body].index "\r\n\r\n", i unless i.nil?
           unless i.nil?

--- a/lib/rspec_api_documentation/example.rb
+++ b/lib/rspec_api_documentation/example.rb
@@ -43,7 +43,17 @@ module RspecApiDocumentation
     end
 
     def requests
-      metadata[:requests] || []
+      reqs = metadata[:requests] || []
+      reqs.each do |req|
+        if req[:request_headers]["Content-Type"].match /\Amultipart\/form-data/
+          i = req[:request_body].index /^Content-Disposition: form-data.* filename=\"/
+          i = req[:request_body].index "\r\n\r\n", i unless i.nil?
+          unless i.nil?
+            req[:request_body] = "#{req[:request_body][0..i+3]}...[truncated file data]..."
+          end
+        end
+      end
+      reqs
     end
   end
 end

--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "i18n", ">= 0.1.0"
   s.add_runtime_dependency "mustache", ">= 0.99.4"
   s.add_runtime_dependency "json", ">= 1.4.6"
+  s.add_runtime_dependency "multipart-parser"
 
   s.add_development_dependency "fakefs"
   s.add_development_dependency "sinatra"


### PR DESCRIPTION
If you upload binary files via `multipart/form-data` then rspec-api-documentation would crash out with encoding errors from `JSON.pretty_generate` (see below). But really you wouldn't want to document the raw file data anyway; so this patch truncates the request body output and update the curl command to support `multipart/form-data` using curl's `-F` switch.

I've been programming Ruby for less than a month and I don't know how best to develop gems so any pointers on things I should have done with this would be appreciated.

```
    * Upload PNG avatar
~/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/json/common.rb:278:in `encode': "\xFF" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/json/common.rb:278:in `generate'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/json/common.rb:278:in `pretty_generate'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/writers/formatter.rb:7:in `to_json'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/writers/json_writer.rb:27:in `block (2 levels) in write'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/writers/json_writer.rb:26:in `open'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/writers/json_writer.rb:26:in `block in write'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/writers/json_writer.rb:23:in `each'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/writers/json_writer.rb:23:in `write'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/writers/json_writer.rb:16:in `write'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/api_documentation.rb:28:in `block in write'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/api_documentation.rb:27:in `each'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/api_documentation.rb:27:in `write'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/api_formatter.rb:42:in `each'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec_api_documentation-2.0.0/lib/rspec_api_documentation/api_formatter.rb:42:in `stop'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:127:in `block in notify'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:126:in `each'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:126:in `notify'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:122:in `stop'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:106:in `finish'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:60:in `report'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:25:in `run'
        from ~/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:80:in `run'
```