### PR TITLE
Decode HTTP basic auth header and generate cURL command with user and password

### DIFF
--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -171,4 +171,18 @@ describe RspecApiDocumentation::Curl do
       curl.output(host)
     end
   end
+
+  describe "Basic Authentication" do
+    let(:method) { "GET" }
+    let(:path) { "/" }
+    let(:data) { "" }
+    let(:headers) do
+      {
+        "HTTP_AUTHORIZATION" => %{Basic dXNlckBleGFtcGxlLm9yZzpwYXNzd29yZA==},
+      }
+    end
+
+    it { should_not =~ /-H "Authorization: Basic dXNlckBleGFtcGxlLm9yZzpwYXNzd29yZA=="/ }
+    it { should =~ /-u user@example\.org:password/ }
+  end
 end


### PR DESCRIPTION
Currently, the generated cURL command for examples that include basic HTTP authentication contains the raw authentication header.

```
curl "http://api.example.org/" -d '' -X GET \
  -H "Authorization: Basic dXNlckBleGFtcGxlLm9yZzpwYXNzd29yZA=="
```

In my opinion, the command is more helpful the way a user would enter it into the terminal, e.g. using cURL's `-u` or `--user` option.

This pull request detects a HTTP basic auth header, decodes it, and generates a corresponding cURL command.

```
curl "http://api.example.org/" -d '' -X GET \
  -u user@example.org:password
```
