### PR TITLE
Fix HTTP basic authentication header detection for cURL example

### DIFF
--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -41,7 +41,7 @@ module RspecApiDocumentation
 
     def headers
       filter_headers(super).map do |k, v|
-        if k == "HTTP_AUTHORIZATION" && v =~ /^Basic/
+        if k =~ /authorization/i && v =~ /^Basic/
           "\\\n\t-u #{format_auth_header(v)}"
         else
           "\\\n\t-H \"#{format_full_header(k, v)}\""


### PR DESCRIPTION
Unfortunately there is a bug in my previous pull request #108.

Headers in specs are written with a `HTTP_` prefix (e.g. `HTTP_AUTHORIZATION`), and given without alteration to the `Curl` class ([source](https://github.com/zipmark/rspec_api_documentation/blob/master/spec/curl_spec.rb#L4)).

When generating the API documentation, headers for `Curl` are set by `ClientBase` ([source](https://github.com/zipmark/rspec_api_documentation/blob/master/lib/rspec_api_documentation/client_base.rb#L63)), which includes `Headers` which formats them nicely (e.g. "Authorization") ([source](https://github.com/zipmark/rspec_api_documentation/blob/master/lib/rspec_api_documentation/headers.rb#L10)).

Therefore the spec is green, but the generated documentation does not show the username and password as desired. This pull request changes one line to use a regular expression to detect the authorization header, either written as `HTTP_AUTHORIZATION` or `Authorization`.
