### PR TITLE
rake docs:generate should generate order docs

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -3,5 +3,5 @@ require 'rspec/core/rake_task'
 desc 'Generate API request documentation from API specs'
 RSpec::Core::RakeTask.new('docs:generate') do |t|
   t.pattern = 'spec/acceptance/**/*_spec.rb'
-  t.rspec_opts = ["--format RspecApiDocumentation::ApiFormatter"]
+  t.rspec_opts = ["--format RspecApiDocumentation::ApiFormatter --order default"]
 end


### PR DESCRIPTION
pass `--order default` args to internal rspec command so that documentation is generated in the same order as it comes in the spec files.
