### PR TITLE
add a rake task for generating docs in the same order specified in specs

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -5,3 +5,9 @@ RSpec::Core::RakeTask.new('docs:generate') do |t|
   t.pattern = 'spec/acceptance/**/*_spec.rb'
   t.rspec_opts = ["--format RspecApiDocumentation::ApiFormatter"]
 end
+
+desc 'Generate API request documentation from API specs (ordered)'
+RSpec::Core::RakeTask.new('docs:generate:ordered') do |t|
+  t.pattern = 'spec/acceptance/**/*_spec.rb'
+  t.rspec_opts = ["--format RspecApiDocumentation::ApiFormatter", "--order default"]
+end


### PR DESCRIPTION
Adding another rake task for generating documentation in the same order as written into the spec files.
