### PR TITLE
add license identifier to gemspec

### DIFF
--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = "A double black belt for your docs"
   s.description = "Generate API docs from your test suite"
   s.homepage    = "http://smartlogicsolutions.com"
+  s.license     = "MIT"
 
   s.required_rubygems_version = ">= 1.3.6"
 


### PR DESCRIPTION
add license identifier to gemspec so that utilities like license_finder can work
