### PR TITLE
Fixing curl generation when nil header is passed

### DIFF
--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -69,7 +69,7 @@ module RspecApiDocumentation
     end
 
     def format_full_header(header, value)
-      formatted_value = value.gsub(/"/, "\\\"")
+      formatted_value = value ? value.gsub(/"/, "\\\"") : ''
       "#{format_header(header)}: #{formatted_value}"
     end
 

--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -15,7 +15,8 @@ describe RspecApiDocumentation::Curl do
         "HTTP_X_HEADER" => "header",
         "HTTP_AUTHORIZATION" => %{Token token="mytoken"},
         "HTTP_HOST" => "example.org",
-        "HTTP_COOKIES" => ""
+        "HTTP_COOKIES" => "",
+        "HTTP_SERVER" => nil
       }
     end
 
@@ -26,6 +27,7 @@ describe RspecApiDocumentation::Curl do
     it { should =~ /-H "Accept: application\/json"/ }
     it { should =~ /-H "X-Header: header"/ }
     it { should =~ /-H "Authorization: Token token=\\"mytoken\\""/ }
+    it { should =~ /-H "Server: "/ }
     it { should_not =~ /-H "Host: example\.org"/ }
     it { should_not =~ /-H "Cookies: "/ }
 


### PR DESCRIPTION
For some reason when trying to use the master on my app the Origin header is being passed as nil and the new exclusion of headers is throwing an error.

This just checks if there's a value before trying to format the header.
