### PR TITLE
Add response_field dsl

### DIFF
--- a/lib/rspec_api_documentation/dsl/resource.rb
+++ b/lib/rspec_api_documentation/dsl/resource.rb
@@ -42,6 +42,10 @@ module RspecApiDocumentation::DSL
         parameters.push(options.merge(:name => name.to_s, :description => description))
       end
 
+      def response_field(name, description, options = {})
+        response_fields.push(options.merge(:name => name.to_s, :description => description))
+      end
+
       def header(name, value)
         headers[name] = value
       end
@@ -53,6 +57,14 @@ module RspecApiDocumentation::DSL
           metadata[:parameters] = Marshal.load(Marshal.dump(superclass_metadata[:parameters]))
         end
         metadata[:parameters]
+      end
+
+      def response_fields
+        metadata[:response_fields] ||= []
+        if superclass_metadata && metadata[:response_fields].equal?(superclass_metadata[:response_fields])
+          metadata[:response_fields] = Marshal.load(Marshal.dump(superclass_metadata[:response_fields]))
+        end
+        metadata[:response_fields]
       end
 
       def headers

--- a/lib/rspec_api_documentation/writers/json_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_writer.rb
@@ -90,6 +90,7 @@ module RspecApiDocumentation
           :description => description,
           :explanation => explanation,
           :parameters => respond_to?(:parameters) ? parameters : [],
+          :response_fields => respond_to?(:response_fields) ? response_fields : [],
           :requests => requests
         }
       end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -58,6 +58,10 @@ resource "Order" do
     parameter :size, "The size of drink you want.", :required => true
     parameter :note, "Any additional notes about your order."
 
+    response_field :type, "The type of drink you ordered."
+    response_field :size, "The size of drink you ordered."
+    response_field :note, "Any additional notes about your order."
+
     let(:type) { "coffee" }
     let(:size) { "medium" }
 
@@ -69,6 +73,16 @@ resource "Order" do
           [
             { :name => "type", :description => "The type of drink you want.", :required => true },
             { :name => "size", :description => "The size of drink you want.", :required => true },
+            { :name => "note", :description => "Any additional notes about your order." }
+          ]
+        )
+      end
+
+      it "should include the documentated response fields" do
+        expect(subject[:response_fields]).to eq (
+          [
+            { :name => "type", :description => "The type of drink you ordered." },
+            { :name => "size", :description => "The size of drink you ordered." },
             { :name => "note", :description => "Any additional notes about your order." }
           ]
         )
@@ -188,6 +202,18 @@ resource "Order" do
 
       it 'should have 2 parameters' do |example|
         expect(example.metadata[:parameters].length).to eq(2)
+      end
+    end
+  end
+
+  describe "nested response_fields" do
+    response_field :per_page, "Number of results on a page"
+
+    context "another response field" do
+      response_field :page, "Current page"
+
+      it "should have 2 response fields" do |example|
+        expect(example.metadata[:response_fields].length).to eq(2)
       end
     end
   end
@@ -450,6 +476,14 @@ resource "top level parameters" do
 
   it 'should have 1 parameter' do |example|
     expect(example.metadata[:parameters].length).to eq(1)
+  end
+end
+
+resource "top level response fields" do
+  response_field :page, "Current page"
+
+  it 'should have 1 response field' do |example|
+    expect(example.metadata[:response_fields].length).to eq(1)
   end
 end
 


### PR DESCRIPTION
It's just add example metadata to help to describe response field(Fix https://github.com/zipmark/rspec_api_documentation/issues/56).
Raddocs, or any other viewers can use metadata.
I'm going to propose a pull request to add response field table to raddocs, if this pull request is merged.
It would be better if the DSL validates real response data, but I have no good idea yet :expressionless:
