### PR TITLE
Supports non ascii characters in example description and resource name

### DIFF
--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -19,11 +19,11 @@ module RspecApiDocumentation
       end
 
       def dirname
-        resource_name.downcase.gsub(/[^0-9a-z.\-]+/, '_')
+        resource_name.downcase.gsub(/\s+/, '_')
       end
 
       def filename
-        basename = description.downcase.gsub(/\s+/, '_').gsub(/[^a-z_]/, '')
+        basename = description.downcase.gsub(/\s+/, '_').gsub(Pathname::SEPARATOR_PAT, '')
         basename = Digest::MD5.new.update(description).to_s if basename.blank?
         "#{basename}.#{extension}"
       end

--- a/lib/rspec_api_documentation/writers/json_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_writer.rb
@@ -78,7 +78,7 @@ module RspecApiDocumentation
       end
 
       def filename
-        basename = description.downcase.gsub(/\s+/, '_').gsub(/[^a-z_]/, '')
+        basename = description.downcase.gsub(/\s+/, '_').gsub(Pathname::SEPARATOR_PAT, '')
         "#{basename}.json"
       end
 

--- a/spec/views/html_example_spec.rb
+++ b/spec/views/html_example_spec.rb
@@ -13,12 +13,11 @@ describe RspecApiDocumentation::Views::HtmlExample do
   end
 
   describe "multi charctor example name" do
-    let(:label) { "コーヒーが順番で並んでいること" }
+    let(:label) { "Coffee / Teaが順番で並んでいること" }
     let(:example) { group.example(label) {} }
 
     it "should have downcased filename" do
-      filename = Digest::MD5.new.update(label).to_s
-      expect(html_example.filename).to eq(filename + ".html")
+      expect(html_example.filename).to eq("coffee__teaが順番で並んでいること.html")
     end
   end
 end

--- a/spec/writers/json_example_spec.rb
+++ b/spec/writers/json_example_spec.rb
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+require 'spec_helper'
+
+describe RspecApiDocumentation::Writers::JsonExample do
+  let(:configuration) { RspecApiDocumentation::Configuration.new }
+
+  describe '#filename' do
+    specify 'Hello!/ 世界' do |example|
+      expect(described_class.new(example, configuration).filename).to eq("hello!_世界.json")
+    end
+  end
+end


### PR DESCRIPTION
similar to https://github.com/zipmark/rspec_api_documentation/pull/41
