### PR TITLE
Add a default post body formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ RspecApiDocumentation.configure do |config|
     # Change the filter to only include :public examples
     config.filter = :public
   end
+
+  # Change how the post body is formatted by default, you can still override by `raw_post`
+  # Can be :json, :xml, or a proc that will be passed the params
+  config.post_body_formatter = Proc.new { |params| params }
 end
 ```
 

--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -1,5 +1,6 @@
 require 'active_support'
 require 'active_support/inflector'
+require 'active_support/core_ext/hash/conversions'
 require 'cgi'
 require 'json'
 

--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -79,6 +79,19 @@ module RspecApiDocumentation
     add_setting :request_headers_to_include, :default => nil
     add_setting :response_headers_to_include, :default => nil
 
+    # Change how the post body is formatted by default, you can still override by `raw_post`
+    # Can be :json, :xml, or a proc that will be passed the params
+    #
+    #   RspecApiDocumentation.configure do |config|
+    #     config.post_body_formatter = Proc.new do |params|
+    #       # convert to whatever you want
+    #       params.to_s
+    #     end
+    #   end
+    #
+    # See RspecApiDocumentation::DSL::Endpoint#do_request
+    add_setting :post_body_formatter, :default => Proc.new { |_| Proc.new { |params| params } }
+
     def client_method=(new_client_method)
       RspecApiDocumentation::DSL::Resource.module_eval <<-RUBY
         alias :#{new_client_method} #{client_method}

--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -38,7 +38,19 @@ module RspecApiDocumentation::DSL
       if method == :get && !query_string.blank?
         path_or_query += "?#{query_string}"
       else
-        params_or_body = respond_to?(:raw_post) ? raw_post : params
+        formatter = RspecApiDocumentation.configuration.post_body_formatter
+        case formatter
+        when :json
+          params_or_body = params.to_json
+        when :xml
+          params_or_body = params.to_xml
+        when Proc
+          params_or_body = formatter.call(params)
+        else
+          params_or_body = params
+        end
+
+        params_or_body = respond_to?(:raw_post) ? raw_post : params_or_body
       end
 
       rspec_api_documentation_client.send(method, path_or_query, params_or_body, headers)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -56,6 +56,10 @@ describe RspecApiDocumentation::Configuration do
     its(:io_docs_protocol) { should == "http" }
     its(:request_headers_to_include) { should be_nil }
     its(:response_headers_to_include) { should be_nil }
+
+    specify "post body formatter" do
+      expect(configuration.post_body_formatter.call({ :page => 1})).to eq({ :page => 1 })
+    end
   end
 
   describe "#define_groups" do

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -471,6 +471,50 @@ resource "Order" do
       end
     end
   end
+
+  context "post body formatter" do
+    after do
+      RspecApiDocumentation.instance_variable_set(:@configuration, RspecApiDocumentation::Configuration.new)
+    end
+
+    post "/orders" do
+      parameter :page, "Page to view"
+
+      let(:page) { 1 }
+
+      specify "formatting by json" do
+        RspecApiDocumentation.configure do |config|
+          config.post_body_formatter = :json
+        end
+
+        expect(client).to receive(method).with(path, { :page => 1 }.to_json , nil)
+
+        do_request
+      end
+
+      specify "formatting by xml" do
+        RspecApiDocumentation.configure do |config|
+          config.post_body_formatter = :xml
+        end
+
+        expect(client).to receive(method).with(path, { :page => 1 }.to_xml , nil)
+
+        do_request
+      end
+
+      specify "formatting by proc" do
+        RspecApiDocumentation.configure do |config|
+          config.post_body_formatter = Proc.new do |params|
+            { :from => "a proc" }.to_json
+          end
+        end
+
+        expect(client).to receive(method).with(path, { :from => "a proc" }.to_json , nil)
+
+        do_request
+      end
+    end
+  end
 end
 
 resource "top level parameters" do


### PR DESCRIPTION
Lets you have all requests be `#to_json`'d without having to `let(:raw_post)` in each context.
