### PR TITLE
Ensure response_body is escaped in html_example template

### DIFF
--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -130,7 +130,7 @@
             <pre class="response status">{{ response_status }} {{ response_status_text}}</pre>
             {{# response_body }}
               <h4>Body</h4>
-              <pre class="response body">{{{ response_body }}}</pre>
+              <pre class="response body">{{ response_body }}</pre>
             {{/ response_body }}
           {{/ response_status }}
         {{/ requests }}


### PR DESCRIPTION
This commit resolves an issue for HTML documents when the `response_body` includes HTML markup. 

For example, if `response_body = {"email":"email1@example.com","name":"<h1>Order 1</h1>","paid":true}`
the generated HTML page won't escape the HTML, and `<h1>Order 1</h1>` will be rendered as a Heading 1. This is so because the mustache template renders the `response_body` using triple curly braces rather than double curly braces. Triple curly braces were introduced to [pretty print the JSON.](https://github.com/zipmark/rspec_api_documentation/commit/f4a600b7f7489d46544163d8647b6e8d996425ff) But this functionality was [later removed,](https://github.com/zipmark/rspec_api_documentation/commit/cd433b2e65772f4393da53a77c33043fe619983f) and I can't see why triple braces are still needed.

(Note: this issue only affects Rails 3 but not Rails 4 apps. I'm not certain why, but I believe it has to do with the changes to JSON handling ([see release notes](http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#changes-in-json-handling)). This patch should be a transparent change for Rails 4 apps.) 
