### PR TITLE
feature/dynamic_response_fields :: Dynamically generates response_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ RspecApiDocumentation.configure do |config|
   # Change how the post body is formatted by default, you can still override by `raw_post`
   # Can be :json, :xml, or a proc that will be passed the params
   config.post_body_formatter = Proc.new { |params| params }
+
+  # Dynamically generates response fields from the actual http response body.
+  # Manually set response_fields take precedence.  Default if off. Set to true to enable.
+  config.dynamic_response_fields = false
 end
 ```
 

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: ../
   specs:
-    rspec_api_documentation (4.0.0.pre)
+    rspec_api_documentation (4.0.0)
       activesupport (>= 3.0.0)
       json (~> 1.4, >= 1.4.6)
       mustache (~> 0.99, >= 0.99.4)
@@ -60,7 +60,7 @@ GEM
     mime-types (1.25.1)
     minitest (5.3.4)
     multi_json (1.10.1)
-    mustache (0.99.5)
+    mustache (0.99.6)
     polyglot (0.3.5)
     rack (1.5.2)
     rack-protection (1.5.3)

--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -91,6 +91,7 @@ module RspecApiDocumentation
     #
     # See RspecApiDocumentation::DSL::Endpoint#do_request
     add_setting :post_body_formatter, :default => Proc.new { |_| Proc.new { |params| params } }
+    add_setting :dynamic_response_fields, :default => false
 
     def client_method=(new_client_method)
       RspecApiDocumentation::DSL::Resource.module_eval <<-RUBY

--- a/lib/rspec_api_documentation/example.rb
+++ b/lib/rspec_api_documentation/example.rb
@@ -100,13 +100,23 @@ module RspecApiDocumentation
       return response.is_a?(Hash) ? response : response.is_a?(Array) ? response.first : response
     end
 
-    def determine_type(v)
-      return "Integer" if v.is_a?(Integer)
-      return "Boolean" if (v == true || v== 'false')
-      return "DateTime" if Date.parse(v) rescue false
-      return "Hash" if v.is_a?(Hash)
-      return "Array" if v.is_a?(Array)
-      return "String"
+    def determine_type(value)
+      case value
+      when Integer
+        "Integer"
+      when TrueClass, FalseClass, "true", "false"
+        "Boolean"
+      when Date
+        "Date"
+      when Time
+        "Time"
+      when Array
+        "Array"
+      when String
+        "String"
+      else
+        "Object"
+      end
     end
   end
 end

--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -5,6 +5,7 @@ module RspecApiDocumentation
     class MarkupExample < Mustache
       def initialize(example, configuration)
         @example = example
+        @requests = @example.metadata[:requests]
         @host = configuration.curl_host
         @filter_headers = configuration.curl_headers_to_filter
         self.template_path = configuration.template_path
@@ -46,6 +47,14 @@ module RspecApiDocumentation
 
       def extension
         raise 'Parent class. This method should not be called.'
+      end
+
+      def sections
+        RspecApiDocumentation::Writers::IndexHelper.sections(examples, @configuration)
+      end
+
+      def examples
+        @index.examples.map { |example| HtmlExample.new(@index, example, @configuration) }
       end
 
       private

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -538,3 +538,35 @@ resource "passing in document to resource", :document => :not_all do
     expect(example.metadata[:document]).to eq(:not_all)
   end
 end
+
+resource "dynamic response fields" do
+  let(:config) do
+    RspecApiDocumentation.configure do |config|
+      config.dynamic_response_fields = true
+    end
+  end
+
+  post "/orders" do
+    parameter :type, "The type of drink you want.", :required => true
+    parameter :size, "The size of drink you want.", :required => true
+    parameter :note, "Any additional notes about your order."
+
+    # response_field :type, "The type of drink you ordered.", :scope => :order
+    # response_field :size, "The size of drink you ordered.", :scope => :order
+    # response_field :note, "Any additional notes about your order.", :scope => :order
+    # response_field :id, "The order id"
+
+    let(:type) { "coffee" }
+    let(:size) { "medium" }
+
+    pending "example metadata" do
+
+      subject { |example| example.metadata}
+
+      it "should include dynamic response fields" do
+        expect(subject[:response_fields]).to_not be_empty
+      end
+    end
+  end
+end
+

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -180,6 +180,37 @@ describe RspecApiDocumentation::Example do
     end
   end
 
+  describe "#determine_type" do
+    it "should return integer" do
+      expect(example.send(:determine_type, 1)).to eq("Integer")
+    end
+
+    it "should return Boolean" do
+      expect(example.send(:determine_type, true)).to eq("Boolean")
+      expect(example.send(:determine_type, false)).to eq("Boolean")
+    end
+
+    it "should return Date" do
+      expect(example.send(:determine_type, Date.new(2001,2,3))).to eq("Date")
+    end
+
+    it "should return Time" do
+      expect(example.send(:determine_type, Time.now)).to eq("Time")
+    end
+
+    it "should return Object" do
+      expect(example.send(:determine_type, {a: 1})).to eq("Object")
+    end
+
+    it "should return Srray" do
+      expect(example.send(:determine_type, [1,2,3])).to eq("Array")
+    end
+
+    it "should return String" do
+      expect(example.send(:determine_type, "String")).to eq("String")
+    end
+  end
+
   describe "request headers can be filtered" do
     before do
       configuration.request_headers_to_include = %w[Included]

--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -76,6 +76,7 @@
               <tr>
                 <th>Name</th>
                 <th>Description</th>
+                <th>Type</th>
               </tr>
             </thead>
             <tbody>
@@ -91,6 +92,9 @@
                 </td>
                 <td>
                   <span class="description">{{ description }}</span>
+                </td>
+                <td>
+                  <span class="type">{{ type }}</span>
                 </td>
               </tr>
               {{/ response_fields }}


### PR DESCRIPTION
In documenting an api with dozens of endpoints, each with dozens of response fields, the manual setting of response fields is tedious.  With proper fixtures/factories/fabricators, there is no need to manually specify the response fields. The resulting http response body should be correct.

Introducing, Dynamic Response Fields. This commit enables the ability to dynamically generate response_fields from actual http response body, including nested attributes with scope.  Manually supplied response_fields take precedent.  Dynamic response fields are disabled by default, but can be enabled through the following configuration:

    config.dynamic_response_fields = true

Works out of the box with Raddocs.

Added Bonus:

The side benefit of dynamic response fields is that for the documentation to be accurate, the test suite must be accurate.  The fixtures/factories/fabricators must accurately represent the live data. Therefore,  improving the documentation, improves the test suite.