### PR TITLE
Update endpoint.rb

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -38,19 +38,21 @@ module RspecApiDocumentation::DSL
       if method == :get && !query_string.blank?
         path_or_query += "?#{query_string}"
       else
-        formatter = RspecApiDocumentation.configuration.post_body_formatter
-        case formatter
-        when :json
-          params_or_body = params.to_json
-        when :xml
-          params_or_body = params.to_xml
-        when Proc
-          params_or_body = formatter.call(params)
+        if respond_to?(:raw_post) 
+          params_or_body = raw_post
         else
-          params_or_body = params
+          formatter = RspecApiDocumentation.configuration.post_body_formatter
+          case formatter
+          when :json
+            params_or_body = params.to_json
+          when :xml
+            params_or_body = params.to_xml
+          when Proc
+            params_or_body = formatter.call(params)
+          else
+            params_or_body = params
+          end
         end
-
-        params_or_body = respond_to?(:raw_post) ? raw_post : params_or_body
       end
 
       rspec_api_documentation_client.send(method, path_or_query, params_or_body, headers)


### PR DESCRIPTION
If the raw_post is stipulated don't calculate the params.  
I did this because when I want the default posts to be JSON, setting the config makes sense.  When I set the config and want to override it (for attachments) then I need the formatting bit of code to not be called because converting the attachment to JSON didn't work.
