### PR TITLE
Remove version ambiguity

### DIFF
--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency "rspec", "~> 3.0.0", ">= 3.0.0"
+  s.add_runtime_dependency "rspec", ">= 3.0.0"
   s.add_runtime_dependency "activesupport", ">= 3.0.0"
   s.add_runtime_dependency "mustache", "~> 0.99", ">= 0.99.4"
   s.add_runtime_dependency "json", "~> 1.4", ">= 1.4.6"


### PR DESCRIPTION
`~> 3.0.0` is already included by `>= 3.0.0`.
