### PR TITLE
fix required css style

### DIFF
--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -4,7 +4,7 @@
     <title>{{resource_name}} API</title>
     <meta charset="utf-8">
     <style>
-      {{ styles }}
+      {{{ styles }}}
     </style>
   </head>
   <body>


### PR DESCRIPTION
`"required"` in this css will be escaped to `&quot;requried&quot;`, which is invaild by Chrome:

```
  td.required .name:after {
  float: right;
  content: "required";
```

So I disabled escaping it by `{{{style}}}` in mustache template.
