### PR TITLE
encoding request_body to utf-8 for Chinese post params

### DIFF
--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -58,7 +58,7 @@ module RspecApiDocumentation
 
       request_metadata[:request_method] = method
       request_metadata[:request_path] = path
-      request_metadata[:request_body] = request_body.empty? ? nil : request_body
+      request_metadata[:request_body] = request_body.empty? ? nil : request_body.force_encoding("UTF-8")
       request_metadata[:request_headers] = request_headers
       request_metadata[:request_query_parameters] = query_hash
       request_metadata[:request_content_type] = request_content_type


### PR DESCRIPTION
When post params has Chinese, error `incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)` will be raised. Just a quick fix.
I think it's same as this issue https://github.com/zipmark/rspec_api_documentation/issues/151
