### PR TITLE
Make DSL work with config.disable_monkeypatching!

### DIFF
--- a/features/example_request.feature
+++ b/features/example_request.feature
@@ -8,8 +8,10 @@ Feature: Example Request
         end
       end
       """
-    And a file named "app_spec.rb" with:
-      """
+
+  Scenario: Output should have the correct error line
+    Given a file named "app_spec.rb" with:
+    """
       require "rspec_api_documentation"
       require "rspec_api_documentation/dsl"
 
@@ -26,11 +28,32 @@ Feature: Example Request
       end
       """
     When  I run `rspec app_spec.rb --require ./app.rb --format RspecApiDocumentation::ApiFormatter`
-
-  Scenario: Output should have the correct error line
     Then the output should contain "expected: 201"
     Then the output should not contain "endpoint.rb"
     Then the output should contain:
       """
       rspec ./app_spec.rb:10 # Example Request GET / Greeting your favorite gem
       """
+
+  Scenario: should work with RSpec monkey patching disabled
+    When a file named "app_spec.rb" with:
+    """
+      require "rspec_api_documentation/dsl"
+
+      RSpec.configure do |config|
+        config.disable_monkey_patching!
+      end
+
+      RspecApiDocumentation.configure do |config|
+        config.app = App
+      end
+
+      RSpec.resource "Example Request" do
+        get "/" do
+          example_request "Greeting your favorite gem" do
+            expect(status).to eq(200)
+          end
+        end
+      end
+      """
+    Then I successfully run `rspec app_spec.rb --require ./app.rb`

--- a/lib/rspec_api_documentation/dsl.rb
+++ b/lib/rspec_api_documentation/dsl.rb
@@ -3,24 +3,33 @@ require "rspec_api_documentation/dsl/resource"
 require "rspec_api_documentation/dsl/endpoint"
 require "rspec_api_documentation/dsl/callback"
 
-# Custom describe block that sets metadata to enable the rest of RAD
-#
-#   resource "Orders", :meta => :data do
-#     # ...
-#   end
-#
-# Params:
-# +args+:: Glob of RSpec's `describe` arguments
-# +block+:: Block to pass into describe
-#
-def self.resource(*args, &block)
-  options = if args.last.is_a?(Hash) then args.pop else {} end
-  options[:api_doc_dsl] = :resource
-  options[:resource_name] = args.first
-  options[:document] ||= :all
-  args.push(options)
-  describe(*args, &block)
+
+module RspecApiDocumentation
+  module DSL
+
+  # Custom describe block that sets metadata to enable the rest of RAD
+  #
+  #   resource "Orders", :meta => :data do
+  #     # ...
+  #   end
+  #
+  # Params:
+  # +args+:: Glob of RSpec's `describe` arguments
+  # +block+:: Block to pass into describe
+  #
+  def resource(*args, &block)
+      options = if args.last.is_a?(Hash) then args.pop else {} end
+      options[:api_doc_dsl] = :resource
+      options[:resource_name] = args.first
+      options[:document] ||= :all
+      args.push(options)
+      describe(*args, &block)
+    end
+  end
 end
+
+RSpec::Core::ExampleGroup.extend(RspecApiDocumentation::DSL)
+RSpec::Core::DSL.expose_example_group_alias(:resource)
 
 RSpec.configuration.include RspecApiDocumentation::DSL::Resource, :api_doc_dsl => :resource
 RSpec.configuration.include RspecApiDocumentation::DSL::Endpoint, :api_doc_dsl => :endpoint


### PR DESCRIPTION
RSpec introduced configuration for disabling monkey patching `main`.

Unfortunately RspecApiDocumentation pollutes main scope by defining `resource` and depending on `describe`.

This patch moves the DSL to a module, extends ExampleGroup and leaves the rest on RSpec.

Also it requires all the dependencies by requiring `rspec_api_documentation` on the top.
