### PR TITLE
Add acceptance to RSpec::Rails::DIRECTORY_MAPPINGS

### DIFF
--- a/lib/rspec_api_documentation/dsl.rb
+++ b/lib/rspec_api_documentation/dsl.rb
@@ -35,3 +35,8 @@ RSpec.configuration.include RspecApiDocumentation::DSL::Resource, :api_doc_dsl =
 RSpec.configuration.include RspecApiDocumentation::DSL::Endpoint, :api_doc_dsl => :endpoint
 RSpec.configuration.include RspecApiDocumentation::DSL::Callback, :api_doc_dsl => :callback
 RSpec.configuration.backtrace_exclusion_patterns << %r{lib/rspec_api_documentation/dsl/}
+
+if defined? RSpec::Rails
+  RSpec::Rails::DIRECTORY_MAPPINGS[:acceptance] = %w[spec acceptance]
+  RSpec.configuration.infer_spec_type_from_file_location!
+end


### PR DESCRIPTION
Adding `:acceptance` to `DIRECTORY_MAPPINGS` and reapplying `infer_spec_type_from_file_location!` you can discern acceptance examples using `example.metadata[:type]`.

In your `spec/rails_helper.rb` for example you could put something like this:

``` ruby
RSpec.configure do |config|
  config.before(:each) do |example|
    # an acceptance example
    if example.metadata[:type] == :acceptance && example.metadata[:auth]
      # stub authentication here
    end
  end
end
```
