### PR TITLE
Remove <p> style from default stylesheet

### DIFF
--- a/lib/rspec_api_documentation/assets/stylesheets/rspec_api_documentation/styles.css
+++ b/lib/rspec_api_documentation/assets/stylesheets/rspec_api_documentation/styles.css
@@ -45,11 +45,6 @@ a{
   font-weight: inherit;
 }
 
-p {
-  padding: 15px;
-  font-size: 130%;
-}
-
 h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
   color: #404040;


### PR DESCRIPTION
`<p>` elements should be left-aligned to the rest of the elements.
