### PR TITLE
Remove explanation escaping

### DIFF
--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -16,7 +16,7 @@
         <h3>{{ http_method }} {{ route }}</h3>
         {{# explanation }}
           <p class="explanation">
-            {{ explanation }}
+            {{{ explanation }}}
           </p>
         {{/ explanation }}
 


### PR DESCRIPTION
This update allows people to write HTML code inside explanations.
