### PR TITLE
Fix for `#to_json` on empty hash creating bad params payload

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -38,13 +38,13 @@ module RspecApiDocumentation::DSL
       if method == :get && !query_string.blank?
         path_or_query += "?#{query_string}"
       else
-        if respond_to?(:raw_post) 
+        if respond_to?(:raw_post)
           params_or_body = raw_post
         else
           formatter = RspecApiDocumentation.configuration.post_body_formatter
           case formatter
           when :json
-            params_or_body = params.to_json
+            params_or_body = params.empty? ? nil : params.to_json
           when :xml
             params_or_body = params.to_xml
           when Proc

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -477,6 +477,18 @@ resource "Order" do
       RspecApiDocumentation.instance_variable_set(:@configuration, RspecApiDocumentation::Configuration.new)
     end
 
+    get "/orders" do
+      specify "formatting by json without parameters" do
+        RspecApiDocumentation.configure do |config|
+          config.post_body_formatter = :json
+        end
+
+        expect(client).to receive(method).with(path, nil, nil)
+
+        do_request
+      end
+    end
+
     post "/orders" do
       parameter :page, "Page to view"
 


### PR DESCRIPTION
This is a proposed patch for issue #183 where a route without specified parameters would generate a invalid JSON payload of `{"{}" => nil}`
