### PR TITLE
Allow resource name be a Class

### DIFF
--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -19,7 +19,7 @@ module RspecApiDocumentation
       end
 
       def dirname
-        resource_name.downcase.gsub(/\s+/, '_').gsub(":", "_")
+        resource_name.to_s.downcase.gsub(/\s+/, '_').gsub(":", "_")
       end
 
       def filename

--- a/lib/rspec_api_documentation/writers/combined_text_writer.rb
+++ b/lib/rspec_api_documentation/writers/combined_text_writer.rb
@@ -44,7 +44,7 @@ module RspecApiDocumentation
       end
 
       def resource_name
-        example.resource_name.downcase.gsub(/\s+/, '_')
+        example.resource_name.to_s.downcase.gsub(/\s+/, '_')
       end
 
       def description

--- a/lib/rspec_api_documentation/writers/json_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_writer.rb
@@ -74,7 +74,7 @@ module RspecApiDocumentation
       end
 
       def dirname
-        resource_name.downcase.gsub(/\s+/, '_')
+        resource_name.to_s.downcase.gsub(/\s+/, '_')
       end
 
       def filename


### PR DESCRIPTION
Allow resource name be a Class, e.g.:
```ruby
resource Postcode do
  # ...
end
```
Prevents `undefined method 'downcase' for #<Class` 