### PR TITLE
Remove leading slashes from dirname

### DIFF
--- a/lib/rspec_api_documentation/writers/json_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_writer.rb
@@ -74,7 +74,7 @@ module RspecApiDocumentation
       end
 
       def dirname
-        resource_name.to_s.downcase.gsub(/\s+/, '_')
+        resource_name.to_s.downcase.gsub(/\s+/, '_').sub(/^\//,'')
       end
 
       def filename

--- a/spec/writers/json_example_spec.rb
+++ b/spec/writers/json_example_spec.rb
@@ -4,6 +4,26 @@ require 'spec_helper'
 describe RspecApiDocumentation::Writers::JsonExample do
   let(:configuration) { RspecApiDocumentation::Configuration.new }
 
+  describe "#dirname" do
+    it "strips out leading slashes" do
+      example = double(resource_name: "/test_string")
+
+      json_example =
+        RspecApiDocumentation::Writers::JsonExample.new(example, configuration)
+
+      expect(json_example.dirname).to eq "test_string"
+    end
+
+    it "does not strip out non-leading slashes" do
+      example = double(resource_name: "test_string/test")
+
+      json_example =
+        RspecApiDocumentation::Writers::JsonExample.new(example, configuration)
+
+      expect(json_example.dirname).to eq "test_string/test"
+    end
+  end
+
   describe '#filename' do
     specify 'Hello!/ 世界' do |example|
       expect(described_class.new(example, configuration).filename).to eq("hello!_世界.json")


### PR DESCRIPTION
* When user names a resource with a leading slash, library was trying to create
  a directory at the root directory of the machine
* Failure was at `lib/rspec_api_documentation/writers/json_writer.rb:18` (which
  is where dir is being made based on resource name)
* This resulted in permissions errors that were hard to debug
* This change strips leading slash when evaluating which dir to put docs into