### PR TITLE
allow inferring contextual params to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ RspecApiDocumentation.configure do |config|
 
   # Removes the DSL method `method`, this is required if you have a parameter named method
   config.disable_dsl_method!
+
+  # By default, examples infer parameter values from context.  Disable to force all
+  # parameters to be explicitly passed to `do_request`
+  config.infer_parameters = true
 end
 ```
 

--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -79,6 +79,7 @@ module RspecApiDocumentation
     add_setting :request_headers_to_include, :default => nil
     add_setting :response_headers_to_include, :default => nil
     add_setting :html_embedded_css_file, :default => nil
+    add_setting :infer_parameters, :default => true
 
     # renamed to request_body_formatter. here for backwards compatibility
     add_setting :post_body_formatter, :default => nil
@@ -149,7 +150,7 @@ module RspecApiDocumentation
     # Yields itself and sub groups to hook into the Enumerable module
     def each(&block)
       yield self
-      groups.map { |g| g.each &block }
+      groups.map { |g| g.each(&block) }
     end
   end
 end

--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -14,7 +14,7 @@ module RspecApiDocumentation::DSL
       def example_request(description, params = {}, &block)
         example description, :caller => block.send(:caller) do
           do_request(params)
-          instance_eval &block if block_given?
+          instance_eval(&block) if block_given?
         end
       end
 
@@ -63,11 +63,14 @@ module RspecApiDocumentation::DSL
     end
 
     def params
-      parameters = example.metadata.fetch(:parameters, {}).inject({}) do |hash, param|
-        set_param(hash, param)
-      end
+      parameters = if RspecApiDocumentation.configuration.infer_parameters
+                     example.metadata.fetch(:parameters, {}).inject({}) do |hash, param|
+                       set_param(hash, param)
+                     end
+                   else
+                     {}
+                   end
       parameters.deep_merge!(extra_params)
-      parameters
     end
 
     def header(name, value)

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -147,6 +147,20 @@ resource "Order" do
         do_request(:extra => true)
       end
 
+      context "when #infer_parameters is disabled" do
+        around(:each) do |example|
+          default = RspecApiDocumentation.configuration.infer_parameters
+          RspecApiDocumentation.configuration.infer_parameters = false
+          example.run
+          RspecApiDocumentation.configuration.infer_parameters = default
+        end
+
+        it "should restrict to extra parameters if #infer_parameters is disabled" do
+          expect(client).to receive(method).with(path, {"extra" => true}, nil)
+          do_request(:extra => true)
+        end
+      end
+
       it "should overwrite parameters" do
         expect(client).to receive(method).with(path, params.merge("size" => "large"), nil)
         do_request(:size => "large")


### PR DESCRIPTION
- sometimes documented parameters match a `let` but arent' meant to be
  used as part of the request
