### PR TITLE
Added a resource explanation.

### DIFF
--- a/lib/rspec_api_documentation/dsl/resource.rb
+++ b/lib/rspec_api_documentation/dsl/resource.rb
@@ -50,6 +50,10 @@ module RspecApiDocumentation::DSL
         headers[name] = value
       end
 
+      def explanation(text)
+        safe_metadata(:resource_explanation, text)
+      end
+
       private
 
       def safe_metadata(field, default)

--- a/lib/rspec_api_documentation/example.rb
+++ b/lib/rspec_api_documentation/example.rb
@@ -42,6 +42,10 @@ module RspecApiDocumentation
       respond_to?(:response_fields) && response_fields.present?
     end
 
+    def resource_explanation
+      metadata[:resource_explanation] || nil
+    end
+
     def explanation
       metadata[:explanation] || nil
     end

--- a/lib/rspec_api_documentation/writers/index_helper.rb
+++ b/lib/rspec_api_documentation/writers/index_helper.rb
@@ -6,7 +6,7 @@ module RspecApiDocumentation
       def sections(examples, configuration)
         resources = examples.group_by(&:resource_name).inject([]) do |arr, (resource_name, examples)|
           ordered_examples = configuration.keep_source_order ? examples : examples.sort_by(&:description)
-          arr.push(:resource_name => resource_name, :examples => ordered_examples)
+          arr.push(:resource_name => resource_name, :examples => ordered_examples, :resource_explanation => examples.first.metadata[:resource_explanation])
         end
         configuration.keep_source_order ? resources : resources.sort_by { |resource| resource[:resource_name] }
       end

--- a/lib/rspec_api_documentation/writers/json_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_writer.rb
@@ -47,6 +47,7 @@ module RspecApiDocumentation
       def section_hash(section)
         {
           :name => section[:resource_name],
+          :explanation => section[:resource_explanation],
           :examples => section[:examples].map { |example|
             {
               :description => example.description,
@@ -85,6 +86,7 @@ module RspecApiDocumentation
       def as_json(opts = nil)
         {
           :resource => resource_name,
+          :resource_explanation => resource_explanation,
           :http_method => http_method,
           :route => route,
           :description => description,

--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -10,6 +10,11 @@
   <body>
     <div class="container">
       <h1>{{resource_name}} API</h1>
+        {{# resource_explanation }}
+            <p class="explanation">
+                {{{ resource_explanation }}}
+            </p>
+        {{/ resource_explanation }}
 
       <div class="article">
         <h2>{{ description }}</h2>

--- a/templates/rspec_api_documentation/html_index.mustache
+++ b/templates/rspec_api_documentation/html_index.mustache
@@ -14,6 +14,11 @@
   {{# sections }}
   <div class="article">
     <h2>{{ resource_name }}</h2>
+    {{# resource_explanation }}
+      <p class="explanation">
+          {{{ resource_explanation }}}
+      </p>
+    {{/ resource_explanation }}
 
     <ul>
       {{# examples }}

--- a/templates/rspec_api_documentation/markdown_example.mustache
+++ b/templates/rspec_api_documentation/markdown_example.mustache
@@ -1,4 +1,8 @@
 # {{ resource_name }} API
+{{# resource_explanation }}
+
+{{ resource_explanation }}
+{{/ resource_explanation }}
 
 ## {{ description }}
 

--- a/templates/rspec_api_documentation/markdown_index.mustache
+++ b/templates/rspec_api_documentation/markdown_index.mustache
@@ -2,6 +2,10 @@
 
 {{# sections }}
 ## {{ resource_name }}
+{{# resource_explanation }}
+
+{{ resource_explanation }}
+{{/ resource_explanation }}
 
 {{# examples }}
 * [{{ description }}]({{ dirname }}/{{ filename }})

--- a/templates/rspec_api_documentation/textile_example.mustache
+++ b/templates/rspec_api_documentation/textile_example.mustache
@@ -1,5 +1,9 @@
 h1. {{ resource_name }} API
 
+{{# resource_explanation }}
+{{ resource_explanation }}
+
+{{/ resource_explanation }}
 h2. {{ description }}
 
 h3. {{ http_method }} {{ route }}

--- a/templates/rspec_api_documentation/textile_index.mustache
+++ b/templates/rspec_api_documentation/textile_index.mustache
@@ -3,6 +3,10 @@ h1. {{ api_name }}
 {{# sections }}
 h2. {{ resource_name }}
 
+{{# resource_explanation }}
+{{ resource_explanation }}
+
+{{/ resource_explanation }}
 {{# examples }}
 * "{{ description }}":{{ dirname }}/{{ filename }}
 {{/ examples }}


### PR DESCRIPTION
I added a way to put explanations on resources. The syntax is the same for explanations. I also modified the templates to put the explanation after the resource name. I felt like this helped to give more options for manual documentation.