### PR TITLE
headers ending in "id" are displayed correctly

### DIFF
--- a/lib/rspec_api_documentation/headers.rb
+++ b/lib/rspec_api_documentation/headers.rb
@@ -8,6 +8,7 @@ module RspecApiDocumentation
         # HTTP_ACCEPT_CHARSET => Accept-Charset
         if key =~ /^(HTTP_|CONTENT_TYPE)/
           header = key.gsub(/^HTTP_/, '').titleize.split.join("-")
+          header.concat('-Id') if key.scan(/_ID\Z/).any?
           headers[header] = value
         end
       end

--- a/spec/http_test_client_spec.rb
+++ b/spec/http_test_client_spec.rb
@@ -62,13 +62,14 @@ describe RspecApiDocumentation::HttpTestClient do
 
   describe "#request_headers" do
     before do
-      test_client.get "/", {}, { "Accept" => "application/json", "Content-Type" => "application/json" }
+      test_client.get "/", {}, { "Accept" => "application/json", "Content-Type" => "application/json", "User-Id" => "1" }
     end
 
     it "should contain all the headers" do
       expect(test_client.request_headers).to eq({
         "Accept" => "application/json",
-        "Content-Type" => "application/json"
+        "Content-Type" => "application/json",
+        "User-Id" => "1"
       })
     end
   end


### PR DESCRIPTION
I had problems with headers, ending with "id". Function titleize cuts "id".