### PR TITLE
Cleans out ASCII_8BIT encoded response bodies

### DIFF
--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -33,6 +33,7 @@ module RspecApiDocumentation
           hash[:request_headers_text] = format_hash(hash[:request_headers])
           hash[:request_query_parameters_text] = format_hash(hash[:request_query_parameters])
           hash[:response_headers_text] = format_hash(hash[:response_headers])
+          hash[:response_body_text] = clean_response_data(hash[:response_body])
           if @host
             if hash[:curl].is_a? RspecApiDocumentation::Curl
               hash[:curl] = hash[:curl].output(@host, @filter_headers)
@@ -49,6 +50,15 @@ module RspecApiDocumentation
       end
 
       private
+
+      def clean_response_data(response_body)
+        return nil if response_body.nil?
+        if response_body.encoding == Encoding::ASCII_8BIT
+          return "[BINARY DATA]"
+        else
+          return response_body
+        end
+      end
 
       def format_hash(hash = {})
         return nil unless hash.present?

--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -112,10 +112,10 @@
             {{/ response_headers_text }}
             <h4>Status</h4>
             <pre class="response status">{{ response_status }} {{ response_status_text}}</pre>
-            {{# response_body }}
+            {{# response_body_text }}
               <h4>Body</h4>
-              <pre class="response body">{{ response_body }}</pre>
-            {{/ response_body }}
+              <pre class="response body">{{ response_body_text }}</pre>
+            {{/ response_body_text }}
           {{/ response_status }}
         {{/ requests }}
       </div>


### PR DESCRIPTION
We have an end point that returns an MP3 for streaming, this allows you to document endpoints that return such binary files.