### PR TITLE
Add bundler gem tasks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ PLATFORMS
 
 DEPENDENCIES
   aruba (~> 0.5)
+  bundler
   capybara (~> 2.2)
   fakefs (~> 0.4)
   faraday (>= 0.9.0)

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require "bundler/gem_tasks"
 
 require "cucumber/rake/task"
 Cucumber::Rake::Task.new(:cucumber)

--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "mustache", "~> 0.99", ">= 0.99.4"
   s.add_runtime_dependency "json", "~> 1.4", ">= 1.4.6"
 
+  s.add_development_dependency "bundler"
   s.add_development_dependency "fakefs", "~> 0.4"
   s.add_development_dependency "sinatra", "~> 1.4.4"
   s.add_development_dependency "aruba", "~> 0.5"


### PR DESCRIPTION
`rake release` helps create tag and push gem to rubygems.