### PR TITLE
added 'route' url and http 'method' for all JsonIndex examples

### DIFF
--- a/lib/rspec_api_documentation/writers/json_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_writer.rb
@@ -51,7 +51,9 @@ module RspecApiDocumentation
             {
               :description => example.description,
               :link => "#{example.dirname}/#{example.filename}",
-              :groups => example.metadata[:document]
+              :groups => example.metadata[:document],
+              :route => example.route,
+              :method => example.metadata[:method]
             }
           }
         }


### PR DESCRIPTION
- store route and http method in JsonIndex to show on index page
- this can make understanding the API request simpler
- no need to check detailed info of API request
- closes #209 