### PR TITLE
Format the JSON response for HTML examples.

### DIFF
--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -33,6 +33,11 @@ module RspecApiDocumentation
           hash[:request_headers_text] = format_hash(hash[:request_headers])
           hash[:request_query_parameters_text] = format_hash(hash[:request_query_parameters])
           hash[:response_headers_text] = format_hash(hash[:response_headers])
+
+          if hash[:response_content_type] =~ /application\/json/
+            hash[:response_body] = JSON.pretty_generate(JSON.parse(hash[:response_body]))
+          end
+
           if @host
             if hash[:curl].is_a? RspecApiDocumentation::Curl
               hash[:curl] = hash[:curl].output(@host, @filter_headers)


### PR DESCRIPTION
Use JSON.pretty_generate to improve format of JSON responses for HTML examples.
![screen shot 2015-07-02 at 7 21 12 am](https://cloud.githubusercontent.com/assets/1002112/8476875/4322d154-208b-11e5-8d9a-670d21597683.png)
