### PR TITLE
Add the ability to set the value of nested params

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ Special values:
 * `:required => true` Will display a red '*' to show it's required
 * `:scope => :the_scope` Will scope parameters in the hash, scoping can be nested. See example
 
+The value of scoped parameters can be set with both scoped (`let(:order_item_item_id)`) and unscoped (`let(:item_id)`) methods. It always searches for the scoped method first and falls back to the unscoped method.
+
 ```ruby
 resource "Orders" do
   parameter :auth_token, "Authentication Token"
@@ -403,8 +405,8 @@ resource "Orders" do
     parameter :item, "Order items", :scope => :order
     parameter :item_id, "Item id", :scope => [:order, :item]
 
-    let(:name) { "My Order" }
-    let(:item_id) { 1 }
+    let(:name) { "My Order" } # OR let(:order_name) { "My Order" }
+    let(:item_id) { 1 } # OR let(:order_item_item_id) { 1 }
 
     example "Creating an order" do
       params.should eq({

--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -148,10 +148,11 @@ module RspecApiDocumentation::DSL
 
     def set_param(hash, param)
       key = param[:name]
-      return hash if in_path?(key)
 
       keys = [param[:scope], key].flatten.compact
       method_name = keys.join('_')
+
+      return hash if in_path?(method_name)
 
       unless respond_to?(method_name)
         method_name = key

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -105,10 +105,12 @@ resource "Order" do
   put "/orders/:id" do
     parameter :type, "The type of drink you want.", :required => true
     parameter :size, "The size of drink you want.", :required => true
+    parameter :id, 'The ID of the resource.', :required => true, scope: :data
     parameter :note, "Any additional notes about your order."
 
     let(:type) { "coffee" }
     let(:size) { "medium" }
+    let(:data_id) { 2 }
 
     let(:id) { 1 }
 
@@ -127,6 +129,10 @@ resource "Order" do
           expect(client).to receive(method).with(path, params, nil)
           do_request
         end
+      end
+
+      it 'should set the scoped data ID' do
+        expect(params['data']).to eq({'id' => 2})
       end
 
       it "should allow extra parameters to be passed in" do


### PR DESCRIPTION
There is a small bug when a parameter is in the path and under some scopes.

```
PUT /articles/:id

{
  "data": {
    "type": "articles",
    "id": "1",
    "attributes": {
      "title": "To TDD or Not"
    }
  }
}
```

It wasn't possible to set the internal `id` because it was checked the presence in the path.

I've changed to check in the path the presence of the full name (with the scope), since the id in the path won't have any scope the following will work:

```
parameter :id, 'path id', required: true
parameter :id, 'data id', scope: :data, required: true

let(:id) { 1 }
let(:data_id) { 1 }
```

I've also improved a bit the readme about scopes