### PR TITLE
Only load the railtie if Rails::Railtie is defined

### DIFF
--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -9,7 +9,7 @@ require 'json'
 module RspecApiDocumentation
   extend ActiveSupport::Autoload
 
-  require 'rspec_api_documentation/railtie' if defined?(Rails)
+  require 'rspec_api_documentation/railtie' if defined?(Rails::Railtie)
   include ActiveSupport::JSON
 
   eager_autoload do


### PR DESCRIPTION
This fixes a problem in a project I am working on. We are working on a non-rails project but pull in some rails libraries for html sanitization. These libraries define Rails but not Rails::Railtie, thus rspec_api_documentation blows up when it tries to load the railtie.