### PR TITLE
Allow Class Resources, call `#to_s` for defined resource_name

### DIFF
--- a/lib/rspec_api_documentation/dsl.rb
+++ b/lib/rspec_api_documentation/dsl.rb
@@ -18,9 +18,9 @@ module RspecApiDocumentation
     # +block+:: Block to pass into describe
     #
     def resource(*args, &block)
-      options = if args.last.is_a?(Hash) then args.pop else {} end
+      options = args.last.is_a?(Hash) ? args.pop : {}
       options[:api_doc_dsl] = :resource
-      options[:resource_name] = args.first
+      options[:resource_name] = args.first.to_s
       options[:document] ||= :all
       args.push(options)
       describe(*args, &block)

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -583,3 +583,10 @@ resource "passing in document to resource", :document => :not_all do
     expect(example.metadata[:document]).to eq(:not_all)
   end
 end
+
+class Order; end
+resource Order do
+  it 'should have a string resource_name' do |example|
+    expect(example.metadata[:resource_name]).to eq(Order.to_s)
+  end
+end


### PR DESCRIPTION
If using a class as the resource:

```ruby
resource Order do
end
```

The `resource_name` will be a class, which causes issues when sorting for
sections. By calling `#to_s` on the `args.first` when first dealing with
the resource we can ensure that we are always working with a string for
the `resource_name`.

-----

Also refactored to use a ternary operator instead of a one-line `if else end`.