### PR TITLE
Fix Content-Type Header

### DIFF
--- a/lib/rspec_api_documentation/headers.rb
+++ b/lib/rspec_api_documentation/headers.rb
@@ -7,8 +7,7 @@ module RspecApiDocumentation
       env.each do |key, value|
         # HTTP_ACCEPT_CHARSET => Accept-Charset
         if key =~ /^(HTTP_|CONTENT_TYPE)/
-          header = key.gsub(/^HTTP_/, '').titleize.split.join("-")
-          header.concat('-Id') if key.scan(/_ID\Z/).any?
+          header = key.gsub(/^HTTP_/, '').split('_').map{|s| s.titleize}.join("-")
           headers[header] = value
         end
       end

--- a/spec/headers_spec.rb
+++ b/spec/headers_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+class FakeHeaderable
+  include RspecApiDocumentation::Headers
+
+  def public_env_to_headers(env)
+    env_to_headers(env)
+  end
+end
+
+describe RspecApiDocumentation::Headers do
+  let(:example) { FakeHeaderable.new }
+  
+  describe '#env_to_headers' do
+    subject { example.public_env_to_headers(env) }
+
+    context 'When the env contains "CONTENT_TYPE"' do
+      let(:env) { { "CONTENT_TYPE" => 'multipart/form-data' } }
+
+      it 'converts the header to "Content-Type"' do
+        expect(subject['Content-Type']).to eq 'multipart/form-data'
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
The Content-Type header was getting mangled to "Content_type". Which caused masking of multipart-data to break.

Fixes #239