### PR TITLE
JSON Content-Type matcher is more inclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ RspecApiDocumentation.configure do |config|
   # Can be :json, :xml, or a proc that will be passed the params
   config.post_body_formatter = Proc.new { |params| params }
 
+  # Change how the response body is formatted by default
+  # Is proc that will be called with the response_content_type & response_body
+  # by default response_content_type of `application/json` are pretty formated.
+  config.response_body_formatter = Proc.new { |response_content_type, response_body| response_body }
+
   # Change the embedded style for HTML output. This file will not be processed by
   # RspecApiDocumentation and should be plain CSS.
   config.html_embedded_css_file = nil

--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -89,10 +89,9 @@ module RspecApiDocumentation
       return nil if response_body.empty?
       if response_body.encoding == Encoding::ASCII_8BIT
         "[binary data]"
-      elsif response_content_type =~ /application\/json/
-        JSON.pretty_generate(JSON.parse(response_body))
       else
-        response_body
+        formatter = RspecApiDocumentation.configuration.response_body_formatter
+        return formatter.call(response_content_type, response_body)
       end
     end
 

--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -93,6 +93,27 @@ module RspecApiDocumentation
     # See RspecApiDocumentation::DSL::Endpoint#do_request
     add_setting :post_body_formatter, :default => Proc.new { |_| Proc.new { |params| params } }
 
+    # Change how the response body is formatted
+    # Can be a proc that will be passed the response body
+    #
+    #   RspecApiDocumentation.configure do |config|
+    #     config.response_body_formatter = Proc.new do |content_type, response_body|
+    #       # convert to whatever you want
+    #       response_body
+    #     end
+    #   end
+    #
+    # See RspecApiDocumentation::DSL::Endpoint#do_request
+    add_setting :response_body_formatter, default: Proc.new { |_, _|
+      Proc.new do |content_type, response_body|
+        if content_type =~ /application\/json/
+          JSON.pretty_generate(JSON.parse(response_body))
+        else
+          response_body
+        end
+      end
+    }
+
     def client_method=(new_client_method)
       RspecApiDocumentation::DSL::Resource.module_eval <<-RUBY
         alias :#{new_client_method} #{client_method}

--- a/spec/http_test_client_spec.rb
+++ b/spec/http_test_client_spec.rb
@@ -133,4 +133,29 @@ describe RspecApiDocumentation::HttpTestClient do
       end
     end
   end
+
+  context "formating response body", :document => true do
+    after do
+      RspecApiDocumentation.instance_variable_set(:@configuration, RspecApiDocumentation::Configuration.new)
+    end
+
+    before do
+      RspecApiDocumentation.configure do |config|
+        config.response_body_formatter =
+          Proc.new do |_, response_body|
+            response_body.upcase
+          end
+      end
+      test_client.post "/greet?query=test+query", post_data, headers
+    end
+
+    let(:post_data) { { :target => "nurse" }.to_json }
+    let(:headers) { { "Content-Type" => "application/json;charset=utf-8", "X-Custom-Header" => "custom header value" } }
+
+    it "it formats the response_body based on the defined proc" do |example|
+      metadata = example.metadata[:requests].first
+      expect(metadata[:response_body]).to be_present
+      expect(metadata[:response_body]).to eq '{"HELLO":"NURSE"}'
+    end
+  end
 end


### PR DESCRIPTION
Supports
- application/json
- application/vnd.api+json
- application/vnd.api+json; supported-ext="bulk,jsonpatch"

the JSON API spec uses `application/vnd.api+json`
http://jsonapi.org/extensions/#extension-negotiation

