### PR TITLE
rename config post_body_formatter to be request_body_formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ RspecApiDocumentation.configure do |config|
 
   # Change how the post body is formatted by default, you can still override by `raw_post`
   # Can be :json, :xml, or a proc that will be passed the params
-  config.post_body_formatter = Proc.new { |params| params }
+  config.request_body_formatter = Proc.new { |params| params }
 
   # Change the embedded style for HTML output. This file will not be processed by
   # RspecApiDocumentation and should be plain CSS.

--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -80,18 +80,21 @@ module RspecApiDocumentation
     add_setting :response_headers_to_include, :default => nil
     add_setting :html_embedded_css_file, :default => nil
 
+    # renamed to request_body_formatter. here for backwards compatibility
+    add_setting :post_body_formatter, :default => nil
+
     # Change how the post body is formatted by default, you can still override by `raw_post`
     # Can be :json, :xml, or a proc that will be passed the params
     #
     #   RspecApiDocumentation.configure do |config|
-    #     config.post_body_formatter = Proc.new do |params|
+    #     config.request_body_formatter = Proc.new do |params|
     #       # convert to whatever you want
     #       params.to_s
     #     end
     #   end
     #
     # See RspecApiDocumentation::DSL::Endpoint#do_request
-    add_setting :post_body_formatter, :default => Proc.new { |_| Proc.new { |params| params } }
+    add_setting :request_body_formatter, :default => Proc.new { |_| RspecApiDocumentation.configuration.post_body_formatter || Proc.new { |params| params } }
 
     def client_method=(new_client_method)
       RspecApiDocumentation::DSL::Resource.module_eval <<-RUBY

--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -41,7 +41,7 @@ module RspecApiDocumentation::DSL
         if respond_to?(:raw_post)
           params_or_body = raw_post
         else
-          formatter = RspecApiDocumentation.configuration.post_body_formatter
+          formatter = RspecApiDocumentation.configuration.request_body_formatter
           case formatter
           when :json
             params_or_body = params.empty? ? nil : params.to_json

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -59,7 +59,7 @@ describe RspecApiDocumentation::Configuration do
     its(:html_embedded_css_file) { should be_nil }
 
     specify "post body formatter" do
-      expect(configuration.post_body_formatter.call({ :page => 1})).to eq({ :page => 1 })
+      expect(configuration.request_body_formatter.call({ :page => 1})).to eq({ :page => 1 })
     end
   end
 

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -515,7 +515,7 @@ resource "Order" do
     get "/orders" do
       specify "formatting by json without parameters" do
         RspecApiDocumentation.configure do |config|
-          config.post_body_formatter = :json
+          config.request_body_formatter = :json
         end
 
         expect(client).to receive(method).with(path, nil, nil)
@@ -531,6 +531,16 @@ resource "Order" do
 
       specify "formatting by json" do
         RspecApiDocumentation.configure do |config|
+          config.request_body_formatter = :json
+        end
+
+        expect(client).to receive(method).with(path, { :page => 1 }.to_json , nil)
+
+        do_request
+      end
+
+      specify "formatting by json via legacy config" do
+        RspecApiDocumentation.configure do |config|
           config.post_body_formatter = :json
         end
 
@@ -541,7 +551,7 @@ resource "Order" do
 
       specify "formatting by xml" do
         RspecApiDocumentation.configure do |config|
-          config.post_body_formatter = :xml
+          config.request_body_formatter = :xml
         end
 
         expect(client).to receive(method).with(path, { :page => 1 }.to_xml , nil)
@@ -551,7 +561,7 @@ resource "Order" do
 
       specify "formatting by proc" do
         RspecApiDocumentation.configure do |config|
-          config.post_body_formatter = Proc.new do |params|
+          config.request_body_formatter = Proc.new do |params|
             { :from => "a proc" }.to_json
           end
         end


### PR DESCRIPTION
Allow legacy configuration `post_body_formatter`

in response to issue https://github.com/zipmark/rspec_api_documentation/issues/243