### PR TITLE
Pass rspec the right --order option (`default` or `defined`).

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -9,5 +9,5 @@ end
 desc 'Generate API request documentation from API specs (ordered)'
 RSpec::Core::RakeTask.new('docs:generate:ordered') do |t|
   t.pattern = 'spec/acceptance/**/*_spec.rb'
-  t.rspec_opts = ["--format RspecApiDocumentation::ApiFormatter", "--order default"]
+  t.rspec_opts = ["--format RspecApiDocumentation::ApiFormatter", "--order defined"]
 end


### PR DESCRIPTION
As I didn't know for sure what exact version the change happened (major > 2?),
I checked inside RSpec::Core::Ordering::Registry.
If we're comfortable with making the switch on version 2 to 3 of RSpec, I can
change the condition to check `Gem.latest_spec_for('rspec-core').version.segments[0]`.

This should fix #192.