### PR TITLE
Ensure that DIRECTORY_MAPPINGS is available

### DIFF
--- a/lib/rspec_api_documentation/dsl.rb
+++ b/lib/rspec_api_documentation/dsl.rb
@@ -2,7 +2,6 @@ require "rspec_api_documentation"
 require "rspec_api_documentation/dsl/resource"
 require "rspec_api_documentation/dsl/endpoint"
 require "rspec_api_documentation/dsl/callback"
-require "rspec/support/warnings"
 
 
 module RspecApiDocumentation

--- a/lib/rspec_api_documentation/dsl.rb
+++ b/lib/rspec_api_documentation/dsl.rb
@@ -2,6 +2,7 @@ require "rspec_api_documentation"
 require "rspec_api_documentation/dsl/resource"
 require "rspec_api_documentation/dsl/endpoint"
 require "rspec_api_documentation/dsl/callback"
+require "rspec/support/warnings"
 
 
 module RspecApiDocumentation
@@ -36,7 +37,7 @@ RSpec.configuration.include RspecApiDocumentation::DSL::Endpoint, :api_doc_dsl =
 RSpec.configuration.include RspecApiDocumentation::DSL::Callback, :api_doc_dsl => :callback
 RSpec.configuration.backtrace_exclusion_patterns << %r{lib/rspec_api_documentation/dsl/}
 
-if defined? RSpec::Rails
+if defined? RSpec::Rails::DIRECTORY_MAPPINGS
   RSpec::Rails::DIRECTORY_MAPPINGS[:acceptance] = %w[spec acceptance]
   RSpec.configuration.infer_spec_type_from_file_location!
 end


### PR DESCRIPTION
Previous, we just check that `RSpec::Rails` was defined, which it can be yet *not* have `RSpec::Rails::DIRECTORY_MAPPINGS` defined. Lets ensure it is defined.