### PR TITLE
Rely on tilde versioning for rspec

### DIFF
--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency "rspec", "~> 3.0", ">= 3.0.0"
+  s.add_runtime_dependency "rspec", "~> 3.0"
   s.add_runtime_dependency "activesupport", ">= 3.0.0"
   s.add_runtime_dependency "mustache", "~> 1.0", ">= 0.99.4"
   s.add_runtime_dependency "json", "~> 1.4", ">= 1.4.6"


### PR DESCRIPTION
This versioning scheme communicates that all rspec versions greater than or equal to 3.0 are supported, by rspec 4 is not. This make sense, sense there is no rspec 4. This change effectively does nothing, but future-proofs us when rspec 4 is released.
