### PR TITLE
Fix inflection bug

### DIFF
--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -77,10 +77,18 @@ module RspecApiDocumentation
     yield configuration if block_given?
   end
 
+  #Transforms hello_world in HelloWorld
+  def self.classify(underscored_string)
+    underscored_string.split('_').map do |string|
+      first_letter, rest = [string[0], string[1..-1]]
+      first_letter.upcase + rest.downcase
+    end.join
+  end
+
+  #Transforms HTTP_HELLO_WORLD in Hello-World
   def self.format_header(header)
     header.gsub(/^HTTP_/, '').split('_').map do |s|
-      first_letter, rest = [s[0], s[1..-1]]
-      first_letter.upcase + rest.downcase
+      self.classify(s)
     end.join("-")
   end
 end

--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -76,4 +76,11 @@ module RspecApiDocumentation
   def self.configure
     yield configuration if block_given?
   end
+
+  def self.format_header(header)
+    header.gsub(/^HTTP_/, '').split('_').map do |s|
+      first_letter, rest = [s[0], s[1..-1]]
+      first_letter.upcase + rest.downcase
+    end.join("-")
+  end
 end

--- a/lib/rspec_api_documentation/api_documentation.rb
+++ b/lib/rspec_api_documentation/api_documentation.rb
@@ -30,7 +30,7 @@ module RspecApiDocumentation
 
     def writers
       [*configuration.format].map do |format|
-        RspecApiDocumentation::Writers.const_get("#{format}_writer".classify)
+        RspecApiDocumentation::Writers.const_get(RspecApiDocumentation.classify("#{format}_writer"))
       end
     end
   end

--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -64,19 +64,15 @@ module RspecApiDocumentation
       ::Base64.decode64(value.split(' ', 2).last || '')
     end
 
-    def format_header(header)
-      header.gsub(/^HTTP_/, '').titleize.split.join("-")
-    end
-
     def format_full_header(header, value)
       formatted_value = value ? value.gsub(/"/, "\\\"") : ''
-      "#{format_header(header)}: #{formatted_value}"
+      "#{RspecApiDocumentation.format_header(header)}: #{formatted_value}"
     end
 
     def filter_headers(headers)
       if !@config_headers_to_filer.empty?
         headers.reject do |header|
-          @config_headers_to_filer.include?(format_header(header))
+          @config_headers_to_filer.include?(RspecApiDocumentation.format_header(header))
         end
       else
         headers

--- a/lib/rspec_api_documentation/headers.rb
+++ b/lib/rspec_api_documentation/headers.rb
@@ -7,7 +7,7 @@ module RspecApiDocumentation
       env.each do |key, value|
         # HTTP_ACCEPT_CHARSET => Accept-Charset
         if key =~ /^(HTTP_|CONTENT_TYPE)/
-          header = key.gsub(/^HTTP_/, '').split('_').map{|s| s.titleize}.join("-")
+          header = RspecApiDocumentation.format_header(key)
           headers[header] = value
         end
       end

--- a/spec/api_documentation_spec.rb
+++ b/spec/api_documentation_spec.rb
@@ -1,5 +1,10 @@
 require 'spec_helper'
 
+#Proves that the inflector related error 'uninitialized constant JSONWriter' is fixed
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'JSON'
+end
+
 describe RspecApiDocumentation::ApiDocumentation do
   let(:configuration) { RspecApiDocumentation::Configuration.new }
   let(:documentation) { RspecApiDocumentation::ApiDocumentation.new(configuration) }

--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -1,4 +1,9 @@
 require 'spec_helper'
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'AUTH'
+end
+
 describe RspecApiDocumentation::Curl do
   let(:host) { "http://example.com" }
   let(:curl) { RspecApiDocumentation::Curl.new(method, path, data, headers) }


### PR DESCRIPTION
If you happen to have an inflection acronym that partially matches one of the uppercase formatted headers as shown in [this test](https://github.com/dcadenas/rspec_api_documentation/blob/54d16b911269b132f5053fbb9067d2deeebad4db/spec/curl_spec.rb) then the doc generated outputs broken headers.

This pull request substitutes `titleize` so that header generation can't be accidentally changed by Rails inflections.
