### PR TITLE
Use tables to represent markdown parameters

### DIFF
--- a/features/markdown_documentation.feature
+++ b/features/markdown_documentation.feature
@@ -226,14 +226,11 @@ Feature: Generate Markdown documentation from test examples
 
     ### Parameters
 
-    Name : name *- required -*
-    Description : Name of order
-
-    Name : amount *- required -*
-    Description : Amount paid
-
-    Name : description
-    Description : Some comments on the order
+    | Name | Description | Required | Scope |
+    |------|-------------|----------|-------|
+    | name | Name of order | true |  |
+    | amount | Amount paid | true |  |
+    | description | Some comments on the order | false |  |
 
     ### Request
 

--- a/lib/rspec_api_documentation/views/markdown_example.rb
+++ b/lib/rspec_api_documentation/views/markdown_example.rb
@@ -8,6 +8,12 @@ module RspecApiDocumentation
         self.template_name = "rspec_api_documentation/markdown_example"
       end
 
+      def parameters
+        super.each do |parameter|
+          parameter[:required] = parameter[:required] ? 'true' : 'false'
+        end
+      end
+
       def extension
         EXTENSION
       end

--- a/templates/rspec_api_documentation/markdown_example.mustache
+++ b/templates/rspec_api_documentation/markdown_example.mustache
@@ -10,10 +10,11 @@
 {{# has_parameters? }}
 
 ### Parameters
-{{# parameters }}
 
-Name : {{ name }}{{# required }} *- required -*{{/ required }}
-Description : {{ description }}
+| Name | Description | Required | Scope |
+|------|-------------|----------|-------|
+{{# parameters }}
+| {{ name }} | {{ description }} | {{ required }} | {{ scope }} |
 {{/ parameters }}
 
 {{/ has_parameters? }}


### PR DESCRIPTION
The parameters in the previous markdown view were pretty ugly, and did not show the `scope` parameters. I made is so parameters are now rendered in a markdown table instead.

I ran into one hitch, I could not for the life of me make the cucumber spec pass. I manually ran:

`be rspec app_spec.rb --require ./app.rb --format RspecApiDocumentation::ApiFormatter`

Against a copy and pasted `app_spec.rb` and `app.rb`, and then diffed the outputs. They were exactly the same. I have no idea how to debug these cucumber tests, so I am probably doing it wrong. Any tips would be hugely appreciated :smile: 

Thanks for maintaining such a useful project!

EDIT: Looks like the specs passed on CI! Must be a local bug.