### PR TITLE
Ignore case sensitivity when filtering headers

### DIFF
--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -76,7 +76,7 @@ module RspecApiDocumentation
     def filter_headers(headers)
       if !@config_headers_to_filer.empty?
         headers.reject do |header|
-          @config_headers_to_filer.include?(format_header(header))
+          @config_headers_to_filer.map(&:downcase).include?(format_header(header).downcase)
         end
       else
         headers

--- a/lib/rspec_api_documentation/example.rb
+++ b/lib/rspec_api_documentation/example.rb
@@ -63,7 +63,7 @@ module RspecApiDocumentation
       requests.each.with_index do |request_hash, index|
         next unless request_hash.key?(key)
         headers = request_hash[key]
-        request_hash[key] = headers.select{ |key, _| headers_to_include.include?(key) }
+        request_hash[key] = headers.select{ |key, _| headers_to_include.map(&:downcase).include?(key.downcase) }
         requests[index] = request_hash
       end
     end

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -193,7 +193,7 @@ describe RspecApiDocumentation::Example do
           },
           {
               :request_headers => {
-                  "Included" => "data",
+                  "included" => "data",
                   "Other" => "not seen"
               },
               :request_method => "GET"
@@ -211,7 +211,7 @@ describe RspecApiDocumentation::Example do
           },
           {
               :request_headers => {
-                  "Included" => "data",
+                  "included" => "data",
               },
               :request_method => "GET"
           }
@@ -232,7 +232,7 @@ describe RspecApiDocumentation::Example do
           },
           {
               :response_headers => {
-                  "Included" => "data",
+                  "included" => "data",
                   "Other" => "not seen"
               },
               :request_method => "GET"
@@ -250,7 +250,7 @@ describe RspecApiDocumentation::Example do
           },
           {
               :response_headers => {
-                  "Included" => "data",
+                  "included" => "data",
               },
               :request_method => "GET"
           }


### PR DESCRIPTION
HTTP headers are case-insensitive, this patch will filter out headers defined on config even if they have different case.