### PR TITLE
remove json as a runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     rspec_api_documentation (4.7.0)
       activesupport (>= 3.0.0)
-      json (~> 1.4, >= 1.4.6)
       mustache (~> 1.0, >= 0.99.4)
       rspec (~> 3.0, >= 3.0.0)
 
@@ -76,7 +75,7 @@ GEM
     multi_json (1.11.2)
     multi_test (0.1.2)
     multipart-post (2.0.0)
-    mustache (1.0.2)
+    mustache (1.0.3)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     pry (0.10.3)

--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "rspec", "~> 3.0", ">= 3.0.0"
   s.add_runtime_dependency "activesupport", ">= 3.0.0"
   s.add_runtime_dependency "mustache", "~> 1.0", ">= 0.99.4"
-  s.add_runtime_dependency "json", "~> 1.4", ">= 1.4.6"
 
   s.add_development_dependency "bundler", "~> 1.0"
   s.add_development_dependency "fakefs", "~> 0.4"


### PR DESCRIPTION
Since JSON is packaged with Ruby 1.9.3, we don't need to add it as a runtime dependency.