### PR TITLE
use rspec < 4.0

### DIFF
--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency "rspec", "~> 3.0", ">= 3.0.0"
+  s.add_runtime_dependency "rspec", "< 4.0"
   s.add_runtime_dependency "activesupport", ">= 3.0.0"
   s.add_runtime_dependency "mustache", "~> 1.0", ">= 0.99.4"
   s.add_runtime_dependency "json", "~> 1.4", ">= 1.4.6"


### PR DESCRIPTION
While trying to use with RSpec 3.5.0.beta3, I was having some issues on the bundle. This solves it :)