### PR TITLE
[WIP] Add option to document contexts

### DIFF
--- a/lib/rspec_api_documentation/example.rb
+++ b/lib/rspec_api_documentation/example.rb
@@ -19,6 +19,10 @@ module RspecApiDocumentation
       super || example.metadata.has_key?(method_sym) || example.respond_to?(method_sym, include_private)
     end
 
+    def description
+      build_documented_context(example_group) + metadata[:description]
+    end
+
     def http_method
       metadata[:method].to_s.upcase
     end
@@ -51,6 +55,21 @@ module RspecApiDocumentation
     end
 
     private
+
+    def build_documented_context(example_group)
+      parent_example_group  = example_group[:parent_example_group]
+      base_description      = if parent_example_group
+                                build_documented_context(parent_example_group)
+                              else
+                                ''
+                              end
+
+      if example_group[:document_context]
+        base_description + example_group[:description] + ' '
+      else
+        base_description
+      end
+    end
 
     def filter_headers(requests)
       requests = remap_headers(requests, :request_headers, configuration.request_headers_to_include)

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -34,6 +34,20 @@ describe RspecApiDocumentation::Example do
     end
   end
 
+  describe '#description' do
+    let(:rspec_example) {
+      rspec_example_group
+        .context('with first-level',  document_context: true)
+        .context('skip this level',   document_context: false)
+        .context('with second-level', document_context: true)
+        .example(description, metadata) {}
+    }
+
+    it 'should include documented contexts' do
+      expect(example.description).to eq 'with first-level with second-level foo'
+    end
+  end
+
   describe "#http_method" do
     let(:metadata) {{ :method => "GET" }}
 


### PR DESCRIPTION
See https://github.com/zipmark/rspec_api_documentation/issues/160

This PR currently requires the addition of the following RSpec config:

``` ruby
config.alias_example_group_to :documented_context, document_context: true
# to work around metadata inheritance
config.alias_example_group_to :describe,           document_context: false
config.alias_example_group_to :context,            document_context: false
```
