### PR TITLE
Escape query_strings in DSL

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -112,9 +112,9 @@ module RspecApiDocumentation::DSL
         if extra_params.keys.include?($1)
           delete_extra_param($1)
         elsif respond_to?($1)
-          send($1)
+          escape send($1)
         else
-          match
+          escape match
         end
       end
     end


### PR DESCRIPTION
i.e. `get "/api/v1/find?query=:my_query"` should escape `:my_query`
