### PR TITLE
Revert "Merge pull request #298 from zipmark/ease-rspec-dep-version"

### DIFF
--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -3,7 +3,7 @@ $:.unshift lib unless $:.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = "rspec_api_documentation"
-  s.version     = "4.8.1"
+  s.version     = "4.8.0"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Chris Cahoon", "Sam Goldman", "Eric Oestrich"]
   s.email       = ["chris@smartlogicsolutions.com", "sam@smartlogicsolutions.com", "eric@smartlogicsolutions.com"]
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_runtime_dependency "rspec",         "~> 3.0"
-  s.add_runtime_dependency "activesupport", "~> 3.0"
-  s.add_runtime_dependency "mustache",      "~> 1.0", ">= 0.99.4"
+  s.add_runtime_dependency "rspec", "~> 3.0", ">= 3.0.0"
+  s.add_runtime_dependency "activesupport", ">= 3.0.0"
+  s.add_runtime_dependency "mustache", "~> 1.0", ">= 0.99.4"
 
   s.add_development_dependency "bundler", "~> 1.0"
   s.add_development_dependency "fakefs", "~> 0.4"


### PR DESCRIPTION
@erictnguyen I mistakenly merged the 'loosen dependency versioning' PR I had opened up: #298.

Could you please review this reversion PR for the time being? Thanks.

cc @jakehow

This reverts commit f4713c3da52c3f13de2e7f5f64731e314a1da9bb, reversing
changes made to d8570ef76247bdbd73d747511f6c4b102cf82875.