### PR TITLE
Remove all windows-illegal characters from filenames

### DIFF
--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -23,7 +23,8 @@ module RspecApiDocumentation
       end
 
       def filename
-        basename = description.downcase.gsub(/\s+/, '_').gsub(Pathname::SEPARATOR_PAT, '')
+        special_chars = /[<>:"\/\\|?*]/
+        basename = description.downcase.gsub(/\s+/, '_').gsub(special_chars, '')
         basename = Digest::MD5.new.update(description).to_s if basename.blank?
         "#{basename}.#{extension}"
       end

--- a/spec/views/html_example_spec.rb
+++ b/spec/views/html_example_spec.rb
@@ -4,7 +4,8 @@ require 'spec_helper'
 describe RspecApiDocumentation::Views::HtmlExample do
   let(:metadata) { { :resource_name => "Orders" } }
   let(:group) { RSpec::Core::ExampleGroup.describe("Orders", metadata) }
-  let(:rspec_example) { group.example("Ordering a cup of coffee") {} }
+  let(:description) { "Ordering a cup of coffee" }
+  let(:rspec_example) { group.example(description) {} }
   let(:rad_example) do
     RspecApiDocumentation::Example.new(rspec_example, configuration)
   end
@@ -17,6 +18,14 @@ describe RspecApiDocumentation::Views::HtmlExample do
 
   it "should have downcased filename" do
     expect(html_example.filename).to eq("ordering_a_cup_of_coffee.html")
+  end
+
+  context "when description contains special characters for Windows OS" do
+    let(:description) { 'foo<>:"/\|?*bar' }
+
+    it "removes them" do
+      expect(html_example.filename).to eq("foobar.html")
+    end
   end
 
   describe "multi charctor example name" do


### PR DESCRIPTION
Using special characters in example descriptions may break `git clone` on Windows when API docs are stored in repo. This is mostly because some of these characters are considered as file separators.
I've decided to remove all characters listed here: https://msdn.microsoft.com/en-ca/library/windows/desktop/aa365247(v=vs.85).aspx#naming_conventions
