### PR TITLE
Add link attribute to JsonExample for JsonWriter

### DIFF
--- a/lib/rspec_api_documentation/writers/json_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_writer.rb
@@ -95,7 +95,8 @@ module RspecApiDocumentation
           :explanation => explanation,
           :parameters => respond_to?(:parameters) ? parameters : [],
           :response_fields => respond_to?(:response_fields) ? response_fields : [],
-          :requests => requests
+          :requests => requests,
+          :link => "#{dirname}/#{filename}"
         }
       end
 


### PR DESCRIPTION
Some viewers use the `link` attribute for viewing specific
examples. [Apitome](https://github.com/modeset/apitome) requires
the attribute to be present for the specific example.
