### PR TITLE
Remove RSpec 3.5 beta mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ Check out a [sample](http://rad-example.herokuapp.com).
 
 Please see the wiki for latest [changes](https://github.com/zipmark/rspec_api_documentation/wiki/Changes).
 
-## RSpec 3.5 Beta
-
-Use the `rspec-3.5` branch until RSpec 3.5 is out of beta.
-
 ## Installation
 
 Add rspec_api_documentation to your Gemfile


### PR DESCRIPTION
RSpec 3.5 has been released. The reference to the beta in the README is obsolete.