### PR TITLE
Use direct path to rake file

### DIFF
--- a/lib/rspec_api_documentation/railtie.rb
+++ b/lib/rspec_api_documentation/railtie.rb
@@ -1,7 +1,7 @@
 module RspecApiDocumentation
   class Railtie < Rails::Railtie
     rake_tasks do
-      load "tasks/docs.rake"
+      load File.join(File.dirname(__FILE__), '../tasks/docs.rake')
     end
   end
 end


### PR DESCRIPTION
Before this, we were relying on the Gem's `lib` dir being on the `$LOAD_PATH`, and thus `load` would find the `tasks/doc.rake` file. This can break when a different gem also has a `tasks/docs.rake` file, and it's further up in the load path. Same goes for a Rails app with a `tasks/docs.rake` file existing. This ensures we get OUR `tasks/docs.rake` file.