### PR TITLE
rspec_api_documentation breaks with mustache 1.0.4

### DIFF
--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -8,6 +8,7 @@ module RspecApiDocumentation
         @host = configuration.curl_host
         @filter_headers = configuration.curl_headers_to_filter
         self.template_path = configuration.template_path
+        super({})
       end
 
       def method_missing(method, *args, &block)

--- a/lib/rspec_api_documentation/views/markup_index.rb
+++ b/lib/rspec_api_documentation/views/markup_index.rb
@@ -7,6 +7,7 @@ module RspecApiDocumentation
         @index = index
         @configuration = configuration
         self.template_path = configuration.template_path
+        super({})
       end
 
       def api_name


### PR DESCRIPTION
[mustache 1.0.4 introduced `initialize` method](https://github.com/mustache/mustache/blob/v1.0.4/lib/mustache.rb#L77-L81) in `Mustache` class. 

You can reproduce by bumping the mustache to v1.0.4 and run the tests:

```
Failures:

  1) RspecApiDocumentation::Writers::HtmlWriter#write should write the index
     Failure/Error: f.write markup_index_class.new(index, configuration).render

     TypeError:
       no implicit conversion of nil into Hash
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:282:in `merge'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:282:in `templateify'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache/settings.rb:154:in `template'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:108:in `render'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:10:in `block in write'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:9:in `open'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:9:in `write'
     # ./spec/writers/html_writer_spec.rb:29:in `block (3 levels) in <top (required)>'

  2) RspecApiDocumentation::Writers::MarkdownWriter#write should write the index
     Failure/Error: f.write markup_index_class.new(index, configuration).render

     TypeError:
       no implicit conversion of nil into Hash
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:282:in `merge'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:282:in `templateify'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache/settings.rb:154:in `template'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:108:in `render'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:10:in `block in write'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:9:in `open'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:9:in `write'
     # ./spec/writers/markdown_writer_spec.rb:29:in `block (3 levels) in <top (required)>'

  3) RspecApiDocumentation::Writers::TextileWriter#write should write the index
     Failure/Error: f.write markup_index_class.new(index, configuration).render

     TypeError:
       no implicit conversion of nil into Hash
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:282:in `merge'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:282:in `templateify'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache/settings.rb:154:in `template'
     # /Users/juanito-fatas/.gem/ruby/2.3.2/gems/mustache-1.0.4/lib/mustache.rb:108:in `render'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:10:in `block in write'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:9:in `open'
     # ./lib/rspec_api_documentation/writers/general_markup_writer.rb:9:in `write'
     # ./spec/writers/textile_writer_spec.rb:29:in `block (3 levels) in <top (required)>'

Finished in 0.60184 seconds (files took 0.89167 seconds to load)
287 examples, 3 failures

Failed examples:

rspec ./spec/writers/html_writer_spec.rb:28 # RspecApiDocumentation::Writers::HtmlWriter#write should write the index
rspec ./spec/writers/markdown_writer_spec.rb:28 # RspecApiDocumentation::Writers::MarkdownWriter#write should write the index
rspec ./spec/writers/textile_writer_spec.rb:28 # RspecApiDocumentation::Writers::TextileWriter#write should write the index
```

This caused our API documents failed to generate. This PR works around it. Not sure what's the best to fix here.

What do you think?