### PR TITLE
Turn off URL globbing parser for curl get requests

### DIFF
--- a/features/slate_documentation.feature
+++ b/features/slate_documentation.feature
@@ -203,7 +203,7 @@ Feature: Generate Slate documentation from test examples
 
 
     ```shell
-    curl "http://localhost:3000/orders" -X GET \
+    curl -g "http://localhost:3000/orders" -X GET \
     	-H "Host: example.org" \
     	-H "Cookie: "
     """

--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -16,7 +16,7 @@ module RspecApiDocumentation
     end
 
     def get
-      "curl \"#{url}#{get_data}\" -X GET #{headers}"
+      "curl -g \"#{url}#{get_data}\" -X GET #{headers}"
     end
 
     def head


### PR DESCRIPTION
Currenly if use with Rails-like collection:
```
GET /endpoint?filter[locations][]=Hamburg
```
it fails with 
```
curl: (3) [globbing] bad range
```

This fix turns off the globbing parser for get requests