### PR TITLE
Fix require in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Set up specs.
     $ vim spec/acceptance/orders_spec.rb
 
 ```ruby
-require 'spec_helper'
+require 'rails_helper'
 require 'rspec_api_documentation/dsl'
 
 resource "Orders" do


### PR DESCRIPTION
Modern version of rails use `rails_helper` instead of `spec_helper` to pull in rails dependencies. With the example as written, the code will not work.

This will fix issues such as https://github.com/zipmark/rspec_api_documentation/issues/258 and http://stackoverflow.com/questions/10536846/why-is-this-rspec-test-throwing-a-undefined-method-call-for-nilnilclass-err