### PR TITLE
Fix integer as header value

### DIFF
--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -69,7 +69,12 @@ module RspecApiDocumentation
     end
 
     def format_full_header(header, value)
-      formatted_value = value ? value.gsub(/"/, "\\\"") : '' unless value.is_a?(Numeric)
+      formatted_value = if value.is_a?(Numeric)
+        value
+      else
+        value ? value.gsub(/"/, "\\\"") : ''
+      end
+
       "#{format_header(header)}: #{formatted_value}"
     end
 

--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -69,7 +69,7 @@ module RspecApiDocumentation
     end
 
     def format_full_header(header, value)
-      formatted_value = value ? value.gsub(/"/, "\\\"") : ''
+      formatted_value = value ? value.gsub(/"/, "\\\"") : '' unless value.is_a?(Numeric)
       "#{format_header(header)}: #{formatted_value}"
     end
 


### PR DESCRIPTION
In my current project a request header has an integer value. 

`RspecApiDocumentation::Curl#format_auth_header` tries to send `#gsub` to the value which Numerics do not respond to. I added a naive check for that.