### PR TITLE
Don't evaluate original parameter name when custom method is provided

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint/set_param.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint/set_param.rb
@@ -45,10 +45,12 @@ module RspecApiDocumentation
         end
 
         def method_name
-          @method_name ||= begin
-            [custom_method_name, scoped_key, key].find do |name|
-              name && example_group.respond_to?(name)
-            end
+          if custom_method_name
+            custom_method_name if example_group.respond_to?(custom_method_name)
+          elsif scoped_key && example_group.respond_to?(scoped_key)
+            scoped_key
+          elsif key && example_group.respond_to?(key)
+            key
           end
         end
 


### PR DESCRIPTION
The `method` arg of `parameter` macro is used to solve conflicts with existing methods on the spec context. This works well when you define the value for `method` arg.
When the specified method is not defined, the original param name is used.

In the example below, the current behavior raises 'No response yet' because `status` is a reserved method of rack test.

```ruby
get '/foo' do
  parameter :status, "Blah", method: :status_param # this param is not required

  example 'meh' do
    expect(status).to eq 200
  end
end
```

The PR removes the fallback that looks for the original param name when the provided `method` is not implemented.

More context here: https://github.com/zipmark/rspec_api_documentation/pull/312#discussion_r126256369