### PR TITLE
Change Json classnames to JSON

### DIFF
--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -39,7 +39,7 @@ module RspecApiDocumentation
     autoload :MarkdownWriter
     autoload :JSONWriter
     autoload :AppendJsonWriter
-    autoload :JSONIodocsWriter
+    autoload :JsonIodocsWriter
     autoload :IndexHelper
     autoload :CombinedTextWriter
     autoload :CombinedJsonWriter

--- a/lib/rspec_api_documentation/api_documentation.rb
+++ b/lib/rspec_api_documentation/api_documentation.rb
@@ -1,3 +1,5 @@
+require 'rspec_api_documentation/writers/json_iodocs_writer'
+
 module RspecApiDocumentation
   class ApiDocumentation
     attr_reader :configuration, :index

--- a/lib/rspec_api_documentation/writers/combined_json_writer.rb
+++ b/lib/rspec_api_documentation/writers/combined_json_writer.rb
@@ -7,7 +7,7 @@ module RspecApiDocumentation
         File.open(configuration.docs_dir.join("combined.json"), "w+") do |f|
           examples = []
           index.examples.each do |rspec_example|
-            examples << Formatter.to_json(JsonExample.new(rspec_example, configuration))
+            examples << Formatter.to_json(JSONExample.new(rspec_example, configuration))
           end
 
           f.write "["

--- a/lib/rspec_api_documentation/writers/json_iodocs_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_iodocs_writer.rb
@@ -32,7 +32,7 @@ module RspecApiDocumentation
       end
 
       def examples
-        @index.examples.map { |example| JsonExample.new(example, @configuration) }
+        @index.examples.map { |example| JSONExample.new(example, @configuration) }
       end
 
       def as_json(opts = nil)
@@ -48,7 +48,7 @@ module RspecApiDocumentation
       end
     end
 
-    class JsonExample
+    class JSONExample
       def initialize(example, configuration)
         @example = example
       end

--- a/lib/rspec_api_documentation/writers/json_iodocs_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_iodocs_writer.rb
@@ -2,7 +2,7 @@ require 'rspec_api_documentation/writers/formatter'
 
 module RspecApiDocumentation
   module Writers
-    class JSONIodocsWriter < Writer
+    class JsonIodocsWriter < Writer
       attr_accessor :api_key
       delegate :docs_dir, :to => :configuration
 
@@ -32,7 +32,7 @@ module RspecApiDocumentation
       end
 
       def examples
-        @index.examples.map { |example| JSONExample.new(example, @configuration) }
+        @index.examples.map { |example| JsonIodocsExample.new(example, @configuration) }
       end
 
       def as_json(opts = nil)
@@ -48,7 +48,7 @@ module RspecApiDocumentation
       end
     end
 
-    class JSONExample
+    class JsonIodocsExample
       def initialize(example, configuration)
         @example = example
       end

--- a/lib/rspec_api_documentation/writers/json_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_writer.rb
@@ -7,14 +7,14 @@ module RspecApiDocumentation
 
       def write
         File.open(docs_dir.join("index.json"), "w+") do |f|
-          f.write Formatter.to_json(JsonIndex.new(index, configuration))
+          f.write Formatter.to_json(JSONIndex.new(index, configuration))
         end
         write_examples
       end
 
       def write_examples
         index.examples.each do |example|
-          json_example = JsonExample.new(example, configuration)
+          json_example = JSONExample.new(example, configuration)
           FileUtils.mkdir_p(docs_dir.join(json_example.dirname))
           File.open(docs_dir.join(json_example.dirname, json_example.filename), "w+") do |f|
             f.write Formatter.to_json(json_example)
@@ -23,7 +23,7 @@ module RspecApiDocumentation
       end
     end
 
-    class JsonIndex
+    class JSONIndex
       def initialize(index, configuration)
         @index = index
         @configuration = configuration
@@ -34,7 +34,7 @@ module RspecApiDocumentation
       end
 
       def examples
-        @index.examples.map { |example| JsonExample.new(example, @configuration) }
+        @index.examples.map { |example| JSONExample.new(example, @configuration) }
       end
 
       def as_json(opts = nil)
@@ -61,7 +61,7 @@ module RspecApiDocumentation
       end
     end
 
-    class JsonExample
+    class JSONExample
       def initialize(example, configuration)
         @example = example
         @host = configuration.curl_host

--- a/spec/writers/json_example_spec.rb
+++ b/spec/writers/json_example_spec.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'spec_helper'
+require 'rspec_api_documentation/writers/json_writer'
 
 describe RspecApiDocumentation::Writers::JSONExample do
   let(:configuration) { RspecApiDocumentation::Configuration.new }

--- a/spec/writers/json_example_spec.rb
+++ b/spec/writers/json_example_spec.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'spec_helper'
 
-describe RspecApiDocumentation::Writers::JsonExample do
+describe RspecApiDocumentation::Writers::JSONExample do
   let(:configuration) { RspecApiDocumentation::Configuration.new }
 
   describe "#dirname" do
@@ -9,7 +9,7 @@ describe RspecApiDocumentation::Writers::JsonExample do
       example = double(resource_name: "/test_string")
 
       json_example =
-        RspecApiDocumentation::Writers::JsonExample.new(example, configuration)
+        RspecApiDocumentation::Writers::JSONExample.new(example, configuration)
 
       expect(json_example.dirname).to eq "test_string"
     end
@@ -18,7 +18,7 @@ describe RspecApiDocumentation::Writers::JsonExample do
       example = double(resource_name: "test_string/test")
 
       json_example =
-        RspecApiDocumentation::Writers::JsonExample.new(example, configuration)
+        RspecApiDocumentation::Writers::JSONExample.new(example, configuration)
 
       expect(json_example.dirname).to eq "test_string/test"
     end

--- a/spec/writers/json_iodocs_writer_spec.rb
+++ b/spec/writers/json_iodocs_writer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RspecApiDocumentation::Writers::JSONIodocsWriter do
+describe RspecApiDocumentation::Writers::JsonIodocsWriter do
   let(:index) { RspecApiDocumentation::Index.new }
   let(:configuration) { RspecApiDocumentation::Configuration.new }
 

--- a/spec/writers/json_iodocs_writer_spec.rb
+++ b/spec/writers/json_iodocs_writer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RspecApiDocumentation::Writers::JsonIodocsWriter do
+describe RspecApiDocumentation::Writers::JSONIodocsWriter do
   let(:index) { RspecApiDocumentation::Index.new }
   let(:configuration) { RspecApiDocumentation::Configuration.new }
 

--- a/spec/writers/json_writer_spec.rb
+++ b/spec/writers/json_writer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RspecApiDocumentation::Writers::JsonWriter do
+describe RspecApiDocumentation::Writers::JSONWriter do
   let(:index) { RspecApiDocumentation::Index.new }
   let(:configuration) { RspecApiDocumentation::Configuration.new }
 


### PR DESCRIPTION
When running the docs:generate command I was getting the following error:

```
/rspec_api_documentation-5.1.0/lib/rspec_api_documentation/api_documentation.rb:33:in `const_get': uninitialized constant RspecApiDocumentation::Writers::JSONWriter (NameError)
```

Turned out to be this line in `RspecApiDocumentation::ApiDocumentation`:

```
RspecApiDocumentation::Writers.const_get("#{format}_writer".classify)
```

apparently `"json_writer".classify` is now returning `JSONWriter` instead of `JsonWriter`, thus giving the uninitialized constant error
