### PR TITLE
Recognize JSON API response as JSON

### DIFF
--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -110,7 +110,7 @@ module RspecApiDocumentation
     # See RspecApiDocumentation::DSL::Endpoint#do_request
     add_setting :response_body_formatter, default: Proc.new { |_, _|
       Proc.new do |content_type, response_body|
-        if content_type =~ /application\/json/
+        if content_type =~ /application\/.*json/
           JSON.pretty_generate(JSON.parse(response_body))
         else
           response_body


### PR DESCRIPTION
Make sure we recognize `application/vnd.api+json` as JSON to pretty format it
using `response_body_formatter`