### PR TITLE
Parameters accept a value option for fixed values.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,19 +65,19 @@ GEM
       sparkr (>= 0.2.0)
       term-ansicolor
       yard (~> 0.8.7.5)
-    json (1.8.3)
+    json (1.8.6)
     method_source (0.8.2)
     mime-types (3.0)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2015.1120)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.3.0)
     minitest (5.8.4)
     multi_json (1.11.2)
     multi_test (0.1.2)
     multipart-post (2.0.0)
     mustache (1.0.3)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -157,4 +157,4 @@ DEPENDENCIES
   webmock (~> 1.7)
 
 BUNDLED WITH
-   1.15.3
+   1.16.1

--- a/lib/rspec_api_documentation/dsl/endpoint/set_param.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint/set_param.rb
@@ -36,6 +36,10 @@ module RspecApiDocumentation
           param[:method]
         end
 
+        def set_value
+          param[:value]
+        end
+
         def path_name
           scoped_key || key
         end
@@ -51,11 +55,14 @@ module RspecApiDocumentation
             scoped_key
           elsif key && example_group.respond_to?(key)
             key
+          elsif key && set_value
+            key
           end
         end
 
         def build_param_hash(keys)
-          value = keys[1] ? build_param_hash(keys[1..-1]) : example_group.send(method_name)
+          value = param[:value] if param.has_key?(:value)
+          value ||= keys[1] ? build_param_hash(keys[1..-1]) : example_group.send(method_name)
           { keys[0].to_s => value }
         end
       end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -62,6 +62,7 @@ resource "Order" do
     parameter :size, "The size of drink you want.", :required => true
     parameter :note, "Any additional notes about your order.", method: :custom_note
     parameter :name, :scope => :order, method: :custom_order_name
+    parameter :quantity, "The quantity of drinks you want.", value: '3'
 
     response_field :type, "The type of drink you ordered.", :scope => :order
     response_field :size, "The size of drink you ordered.", :scope => :order
@@ -88,6 +89,7 @@ resource "Order" do
             { :name => "size", :description => "The size of drink you want.", :required => true },
             { :name => "note", :description => "Any additional notes about your order.", method: :custom_note },
             { :name => "name", :description => "Order name", :scope => :order, method: :custom_order_name },
+            { :name => "quantity", :description => "The quantity of drinks you want.", value: '3' }
           ]
         )
       end
@@ -114,7 +116,8 @@ resource "Order" do
             "type" => "coffee",
             "size" => "medium",
             "note" => "Made in India",
-            "order" => { "name" => "Jakobz" }
+            "order" => { "name" => "Jakobz" },
+            "quantity" => "3"
           })
         end
       end


### PR DESCRIPTION
## Background

When building out a JSONAPI, every endpoint has a `type` field with a fixed value of the resources name. Writing `parameter :type, 'The object type', value: 'users'` is more clear of it's static nature than looking for a `let`.

More broadly, when using `rspec_api_documentation` for 10-15 projects now. Having `let` reserved for dynamic values and using `value: 3` for things that are static, seems to reduce the "noise" in writing larger spec files.

## Need Feedback

Not 100% sure on the `value:` naming convention. I also tried having `method` support a block (like  `method: -> { '3' }`), but that did not feel right.

## Notes

* The specs suite does not seem to like Ruby 2.5.0 with the current `Gemfile.lock`. I suggest removing the `Gemfile.lock` from the repo (`gitignore` it) and depend on the `gemspec`.
* I had to upgrade the `json` gem in order to run bundle on Ruby 2.5 / OSX 10.13