### PR TITLE
Fix API blueprint documentation

### DIFF
--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -354,7 +354,7 @@ Feature: Generate API Blueprint documentation from test examples
                   ]
                 }
 
-    ## Single Order [/orders/:id{?optional=:optional}]
+    ## Single Order [/orders{/id}{?optional=:optional}]
 
     + Parameters
       + id: 1 (required, string) - Order id

--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -262,18 +262,18 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-            Host: example.org
+                Host: example.org
 
     + Response 200 (text/html;charset=utf-8)
 
         + Headers
 
-            Content-Type: text/html;charset=utf-8
-            Content-Length: 57
+                Content-Type: text/html;charset=utf-8
+                Content-Length: 57
 
         + Body
 
-            {"data":{"id":"1","type":"instructions","attributes":{}}}
+                {"data":{"id":"1","type":"instructions","attributes":{}}}
 
     # Group Orders
 
@@ -287,38 +287,38 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-            Content-Type: application/json
-            Host: example.org
+                Content-Type: application/json
+                Host: example.org
 
         + Body
 
-            {
-              "data": {
-                "type": "order",
-                "attributes": {
-                  "name": "Order 1",
-                  "amount": 100.0,
-                  "description": "A description"
+                {
+                  "data": {
+                    "type": "order",
+                    "attributes": {
+                      "name": "Order 1",
+                      "amount": 100.0,
+                      "description": "A description"
+                    }
+                  }
                 }
-              }
-            }
 
     + Response 201 (application/json)
 
         + Headers
 
-            Content-Type: application/json
-            Content-Length: 73
+                Content-Type: application/json
+                Content-Length: 73
 
         + Body
 
-            {
-              "order": {
-                "name": "Order 1",
-                "amount": 100.0,
-                "description": "A great order"
-              }
-            }
+                {
+                  "order": {
+                    "name": "Order 1",
+                    "amount": 100.0,
+                    "description": "A great order"
+                  }
+                }
 
     ### Return all orders [GET]
 
@@ -326,32 +326,32 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-            Host: example.org
+                Host: example.org
 
     + Response 200 (application/vnd.api+json)
 
         + Headers
 
-            Content-Type: application/vnd.api+json
-            Content-Length: 137
+                Content-Type: application/vnd.api+json
+                Content-Length: 137
 
         + Body
 
-            {
-              "page": 1,
-              "orders": [
                 {
-                  "name": "Order 1",
-                  "amount": 9.99,
-                  "description": null
-                },
-                {
-                  "name": "Order 2",
-                  "amount": 100.0,
-                  "description": "A great order"
+                  "page": 1,
+                  "orders": [
+                    {
+                      "name": "Order 1",
+                      "amount": 9.99,
+                      "description": null
+                    },
+                    {
+                      "name": "Order 2",
+                      "amount": 100.0,
+                      "description": "A great order"
+                    }
+                  ]
                 }
-              ]
-            }
 
     ## Single Order [/orders/:id{?optional=:optional}]
 
@@ -370,15 +370,15 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-            Host: example.org
-            Content-Type: application/x-www-form-urlencoded
+                Host: example.org
+                Content-Type: application/x-www-form-urlencoded
 
     + Response 200 (text/html;charset=utf-8)
 
         + Headers
 
-            Content-Type: text/html;charset=utf-8
-            Content-Length: 0
+                Content-Type: text/html;charset=utf-8
+                Content-Length: 0
 
     ### Returns a single order [GET]
 
@@ -386,24 +386,24 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-            Host: example.org
+                Host: example.org
 
     + Response 200 (application/json)
 
         + Headers
 
-            Content-Type: application/json
-            Content-Length: 73
+                Content-Type: application/json
+                Content-Length: 73
 
         + Body
 
-            {
-              "order": {
-                "name": "Order 1",
-                "amount": 100.0,
-                "description": "A great order"
-              }
-            }
+                {
+                  "order": {
+                    "name": "Order 1",
+                    "amount": 100.0,
+                    "description": "A great order"
+                  }
+                }
 
     ### Updates a single order [PUT]
 
@@ -411,55 +411,55 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-            Content-Type: application/json; charset=utf-16
-            Host: example.org
+                Content-Type: application/json; charset=utf-16
+                Host: example.org
 
     + Response 400 (application/json)
 
         + Headers
 
-            Content-Type: application/json
-            Content-Length: 0
+                Content-Type: application/json
+                Content-Length: 0
 
     + Request Update an order (application/json; charset=utf-16)
 
         + Headers
 
-            Content-Type: application/json; charset=utf-16
-            Host: example.org
+                Content-Type: application/json; charset=utf-16
+                Host: example.org
 
         + Body
 
-            {
-              "data": {
-                "id": "1",
-                "type": "order",
-                "attributes": {
-                  "name": "Order 1"
+                {
+                  "data": {
+                    "id": "1",
+                    "type": "order",
+                    "attributes": {
+                      "name": "Order 1"
+                    }
+                  }
                 }
-              }
-            }
 
     + Response 200 (application/json)
 
         + Headers
 
-            Content-Type: application/json
-            Content-Length: 111
+                Content-Type: application/json
+                Content-Length: 111
 
         + Body
 
-            {
-              "data": {
-                "id": "1",
-                "type": "order",
-                "attributes": {
-                  "name": "Order 1",
-                  "amount": 100.0,
-                  "description": "A description"
+                {
+                  "data": {
+                    "id": "1",
+                    "type": "order",
+                    "attributes": {
+                      "name": "Order 1",
+                      "amount": 100.0,
+                      "description": "A description"
+                    }
+                  }
                 }
-              }
-            }
     """
 
   Scenario: Example 'Deleting an order' file should not be created

--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -354,7 +354,7 @@ Feature: Generate API Blueprint documentation from test examples
                   ]
                 }
 
-    ## Single Order [/orders{/id}{?optional=:optional}]
+    ## Single Order [/orders/{id}{?optional=:optional}]
 
     + Parameters
       + id: 1 (required, string) - Order id

--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -248,7 +248,7 @@ Feature: Generate API Blueprint documentation from test examples
   Scenario: Index file should look like we expect
     Then the file "doc/api/index.apib" should contain exactly:
     """
-    FORMAT: A1
+    FORMAT: 1A
 
     # Group Instructions
 

--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -269,7 +269,6 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-                Content-Type: text/html;charset=utf-8
                 Content-Length: 57
 
         + Body
@@ -288,7 +287,6 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-                Content-Type: application/json
                 Host: example.org
 
         + Body
@@ -308,7 +306,6 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-                Content-Type: application/json
                 Content-Length: 73
 
         + Body
@@ -333,7 +330,6 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-                Content-Type: application/vnd.api+json
                 Content-Length: 137
 
         + Body
@@ -372,13 +368,11 @@ Feature: Generate API Blueprint documentation from test examples
         + Headers
 
                 Host: example.org
-                Content-Type: application/x-www-form-urlencoded
 
     + Response 200 (text/html;charset=utf-8)
 
         + Headers
 
-                Content-Type: text/html;charset=utf-8
                 Content-Length: 0
 
     ### Returns a single order [GET]
@@ -393,7 +387,6 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-                Content-Type: application/json
                 Content-Length: 73
 
         + Body
@@ -412,21 +405,18 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-                Content-Type: application/json; charset=utf-16
                 Host: example.org
 
     + Response 400 (application/json)
 
         + Headers
 
-                Content-Type: application/json
                 Content-Length: 0
 
     + Request Update an order (application/json; charset=utf-16)
 
         + Headers
 
-                Content-Type: application/json; charset=utf-16
                 Host: example.org
 
         + Body
@@ -445,7 +435,6 @@ Feature: Generate API Blueprint documentation from test examples
 
         + Headers
 
-                Content-Type: application/json
                 Content-Length: 111
 
         + Body

--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -249,6 +249,7 @@ Feature: Generate API Blueprint documentation from test examples
     Then the file "doc/api/index.apib" should contain exactly:
     """
     FORMAT: 1A
+    # Example API
 
     # Group Instructions
 

--- a/lib/rspec_api_documentation/dsl/endpoint/params.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint/params.rb
@@ -13,11 +13,14 @@ module RspecApiDocumentation
         end
 
         def call
-          parameters = example.metadata.fetch(:parameters, {}).inject({}) do |hash, param|
+          set_param = -> hash, param {
             SetParam.new(self, hash, param).call
-          end
-          parameters.deep_merge!(extra_params)
-          parameters
+          }
+
+          example.metadata.fetch(:parameters, {}).inject({}, &set_param)
+            .deep_merge(
+              example.metadata.fetch(:attributes, {}).inject({}, &set_param)
+            ).deep_merge(extra_params)
         end
 
       private

--- a/lib/rspec_api_documentation/views/api_blueprint_example.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_example.rb
@@ -1,7 +1,7 @@
 module RspecApiDocumentation
   module Views
     class ApiBlueprintExample < MarkupExample
-      TOTAL_SPACES_INDENTATION = 8.freeze
+      TOTAL_SPACES_INDENTATION = 12.freeze
 
       def initialize(example, configuration)
         super

--- a/lib/rspec_api_documentation/views/api_blueprint_example.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_example.rb
@@ -20,14 +20,14 @@ module RspecApiDocumentation
 
       def requests
         super.map do |request|
-          request[:request_headers_text]  = remove_utf8_for_json(request[:request_headers_text])
+          request[:request_headers_text]  = remove_utf8_for_json(remove_content_type(request[:request_headers_text]))
           request[:request_headers_text]  = indent(request[:request_headers_text])
           request[:request_content_type]  = content_type(request[:request_headers])
           request[:request_content_type]  = remove_utf8_for_json(request[:request_content_type])
           request[:request_body]          = body_to_json(request, :request)
           request[:request_body]          = indent(request[:request_body])
 
-          request[:response_headers_text] = remove_utf8_for_json(request[:response_headers_text])
+          request[:response_headers_text] = remove_utf8_for_json(remove_content_type(request[:response_headers_text]))
           request[:response_headers_text] = indent(request[:response_headers_text])
           request[:response_content_type] = content_type(request[:response_headers])
           request[:response_content_type] = remove_utf8_for_json(request[:response_content_type])
@@ -45,6 +45,18 @@ module RspecApiDocumentation
       end
 
       private
+
+      # `Content-Type` header is removed because the information would be duplicated
+      # since it's already present in `request[:request_content_type]`.
+      def remove_content_type(headers)
+        return unless headers
+        headers
+          .split("\n")
+          .reject { |header|
+            header.start_with?('Content-Type:')
+          }
+          .join("\n")
+      end
 
       def has_request?(metadata)
         metadata.any? do |key, value|

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -46,13 +46,13 @@ module RspecApiDocumentation
       private
 
       # APIB follows the RFC 6570 to format URI templates.
-      # According to it, path segment expansion (used to describe URI path
-      # hierarchies) should be represented by `{/var}` and not by `/:var`
-      # For example `/posts/:id` should become `/posts{/id}`
+      # According to it, simple string expansion (used to perform variable
+      # expansion) should be represented by `{var}` and not by `/:var`
+      # For example `/posts/:id` should become `/posts/{id}`
       # cf. https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#431-resource-section
       # cf. https://tools.ietf.org/html/rfc6570#section-3.2.6
       def format_route(example)
-        route_uri = example[:route_uri].gsub(/\/:(.*?)([.\/?{]|$)/, '{/\1}\2')
+        route_uri = example[:route_uri].gsub(/:(.*?)([.\/?{]|$)/, '{\1}\2')
         "#{route_uri}#{example[:route_optionals]}"
       end
 

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -23,7 +23,7 @@ module RspecApiDocumentation
             {
               "has_attributes?".to_sym => attrs.size > 0,
               "has_parameters?".to_sym => params.size > 0,
-              route: route,
+              route: format_route(examples[0]),
               route_name: examples[0][:route_name],
               attributes: attrs,
               parameters: params,
@@ -44,6 +44,17 @@ module RspecApiDocumentation
       end
 
       private
+
+      # APIB follows the RFC 6570 to format URI templates.
+      # According to it, path segment expansion (used to describe URI path
+      # hierarchies) should be represented by `{/var}` and not by `/:var`
+      # For example `/posts/:id` should become `/posts{/id}`
+      # cf. https://github.com/apiaryio/api-blueprint/blob/format-1A/API%20Blueprint%20Specification.md#431-resource-section
+      # cf. https://tools.ietf.org/html/rfc6570#section-3.2.6
+      def format_route(example)
+        route_uri = example[:route_uri].gsub(/\/:(.*?)([.\/?{]|$)/, '{/\1}\2')
+        "#{route_uri}#{example[:route_optionals]}"
+      end
 
       # APIB has both `parameters` and `attributes`. This generates a hash
       # with all of its properties, like name, description, required.

--- a/spec/views/api_blueprint_example_spec.rb
+++ b/spec/views/api_blueprint_example_spec.rb
@@ -57,17 +57,9 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
     describe 'request_headers_text' do
       subject { view.requests[0][:request_headers_text] }
 
-      context 'when charset=utf-8 is present' do
-        it "just strips that because it's the default for json" do
-          expect(subject).to eq "Content-Type: application/json\n            Another: header; charset=utf-8"
-        end
-      end
-
-      context 'when charset=utf-16 is present' do
-        let(:content_type) { "application/json; charset=utf-16" }
-
-        it "keeps that because it's NOT the default for json" do
-          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n            Another: header; charset=utf-8"
+      context 'when Content-Type is present' do
+        it "removes it" do
+          expect(subject).to eq "Another: header; charset=utf-8"
         end
       end
     end
@@ -93,17 +85,9 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
     describe 'response_headers_text' do
       subject { view.requests[0][:response_headers_text] }
 
-      context 'when charset=utf-8 is present' do
-        it "just strips that because it's the default for json" do
-          expect(subject).to eq "Content-Type: application/json\n            Another: header; charset=utf-8"
-        end
-      end
-
-      context 'when charset=utf-16 is present' do
-        let(:content_type) { "application/json; charset=utf-16" }
-
-        it "keeps that because it's NOT the default for json" do
-          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n            Another: header; charset=utf-8"
+      context 'when Content-Type is present' do
+        it "removes it" do
+          expect(subject).to eq "Another: header; charset=utf-8"
         end
       end
     end

--- a/spec/views/api_blueprint_example_spec.rb
+++ b/spec/views/api_blueprint_example_spec.rb
@@ -59,7 +59,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
 
       context 'when charset=utf-8 is present' do
         it "just strips that because it's the default for json" do
-          expect(subject).to eq "Content-Type: application/json\n        Another: header; charset=utf-8"
+          expect(subject).to eq "Content-Type: application/json\n            Another: header; charset=utf-8"
         end
       end
 
@@ -67,7 +67,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
         let(:content_type) { "application/json; charset=utf-16" }
 
         it "keeps that because it's NOT the default for json" do
-          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n        Another: header; charset=utf-8"
+          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n            Another: header; charset=utf-8"
         end
       end
     end
@@ -95,7 +95,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
 
       context 'when charset=utf-8 is present' do
         it "just strips that because it's the default for json" do
-          expect(subject).to eq "Content-Type: application/json\n        Another: header; charset=utf-8"
+          expect(subject).to eq "Content-Type: application/json\n            Another: header; charset=utf-8"
         end
       end
 
@@ -103,7 +103,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintExample do
         let(:content_type) { "application/json; charset=utf-16" }
 
         it "keeps that because it's NOT the default for json" do
-          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n        Another: header; charset=utf-8"
+          expect(subject).to eq "Content-Type: application/json; charset=utf-16\n            Another: header; charset=utf-8"
         end
       end
     end

--- a/spec/views/api_blueprint_index_spec.rb
+++ b/spec/views/api_blueprint_index_spec.rb
@@ -109,7 +109,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
         post_examples = post_route[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(post_examples.size).to eq 2
-        expect(post_route[:route]).to eq "/posts/:id"
+        expect(post_route[:route]).to eq "/posts{/id}"
         expect(post_route[:route_name]).to eq "Single Post"
         expect(post_route[:has_parameters?]).to eq true
         expect(post_route[:parameters]).to eq [{
@@ -130,7 +130,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
         post_w_optionals_examples = post_route_with_optionals[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(post_w_optionals_examples.size).to eq 1
-        expect(post_route_with_optionals[:route]).to eq "/posts/:id{?option=:option}"
+        expect(post_route_with_optionals[:route]).to eq "/posts{/id}{?option=:option}"
         expect(post_route_with_optionals[:route_name]).to eq "Single Post"
         expect(post_route_with_optionals[:has_parameters?]).to eq true
         expect(post_route_with_optionals[:parameters]).to eq [{

--- a/spec/views/api_blueprint_index_spec.rb
+++ b/spec/views/api_blueprint_index_spec.rb
@@ -109,7 +109,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
         post_examples = post_route[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(post_examples.size).to eq 2
-        expect(post_route[:route]).to eq "/posts{/id}"
+        expect(post_route[:route]).to eq "/posts/{id}"
         expect(post_route[:route_name]).to eq "Single Post"
         expect(post_route[:has_parameters?]).to eq true
         expect(post_route[:parameters]).to eq [{
@@ -130,7 +130,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
 
         post_w_optionals_examples = post_route_with_optionals[:http_methods].map { |http_method| http_method[:examples] }.flatten
         expect(post_w_optionals_examples.size).to eq 1
-        expect(post_route_with_optionals[:route]).to eq "/posts{/id}{?option=:option}"
+        expect(post_route_with_optionals[:route]).to eq "/posts/{id}{?option=:option}"
         expect(post_route_with_optionals[:route_name]).to eq "Single Post"
         expect(post_route_with_optionals[:has_parameters?]).to eq true
         expect(post_route_with_optionals[:parameters]).to eq [{

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -1,4 +1,4 @@
-FORMAT: A1
+FORMAT: 1A
 {{# sections }}
 
 # Group {{ resource_name }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -1,4 +1,5 @@
 FORMAT: 1A
+# {{ api_name }}
 {{# sections }}
 
 # Group {{ resource_name }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -48,13 +48,13 @@ explanation: {{ explanation }}
 
     + Headers
 
-        {{{ request_headers_text }}}
+            {{{ request_headers_text }}}
 {{/ request_headers_text }}
 {{# request_body }}
 
     + Body
 
-        {{{ request_body }}}
+            {{{ request_body }}}
 {{/ request_body }}
 {{# has_response? }}
 
@@ -64,13 +64,13 @@ explanation: {{ explanation }}
 
     + Headers
 
-        {{{ response_headers_text }}}
+            {{{ response_headers_text }}}
 {{/ response_headers_text }}
 {{# response_body }}
 
     + Body
 
-        {{{ response_body }}}
+            {{{ response_body }}}
 {{/ response_body }}
 {{/ requests }}
 {{/ examples }}


### PR DESCRIPTION
The API Blueprint generated is wrong and don't work on https://app.apiary.io this PR aim to fix that.

This is the minimum changes to make https://app.apiary.io happy.

This PR is based on the work of 

[Fabien Chaynes](https://github.com/FabienChaynes) @FabienChaynes https://github.com/FinalCAD/rspec_api_documentation/pull/1 and [Steven Vandevelde](https://github.com/icidasset)  @icidasset https://github.com/FinalCAD/rspec_api_documentation/pull/2

They did more, but I think it should be part of another PR.

Please consider those changes.

Thanks