### PR TITLE
Add index template and api explanation for Slate formatter

### DIFF
--- a/features/slate_documentation.feature
+++ b/features/slate_documentation.feature
@@ -49,7 +49,7 @@ Feature: Generate Slate documentation from test examples
       RspecApiDocumentation.configure do |config|
         config.app = App
         config.api_name = "Example API"
-        config.api_explanation = "Description"
+        config.api_explanation = "An explanation of the API"
         config.format = :slate
         config.curl_host = 'http://localhost:3000'
         config.request_headers_to_include = %w[Content-Type Host]
@@ -292,4 +292,10 @@ Feature: Generate Slate documentation from test examples
     Then the file "doc/api/index.html.md" should contain:
     """
     ## Getting welcome message
+    """
+
+  Scenario: API explanation should be included
+    Then the file "doc/api/index.html.md" should contain:
+    """
+    An explanation of the API
     """

--- a/lib/rspec_api_documentation/views/slate_index.rb
+++ b/lib/rspec_api_documentation/views/slate_index.rb
@@ -1,6 +1,10 @@
 module RspecApiDocumentation
   module Views
     class SlateIndex < MarkdownIndex
+      def initialize(index, configuration)
+        super
+        self.template_name = "rspec_api_documentation/slate_index"
+      end
     end
   end
 end

--- a/lib/rspec_api_documentation/writers/slate_writer.rb
+++ b/lib/rspec_api_documentation/writers/slate_writer.rb
@@ -21,14 +21,7 @@ module RspecApiDocumentation
       def write
         File.open(configuration.docs_dir.join("#{FILENAME}.#{extension}"), 'w+') do |file|
 
-          file.write %Q{---\n}
-          file.write %Q{title: "#{configuration.api_name}"\n}
-          file.write %Q{language_tabs:\n}
-          file.write %Q{  - json: JSON\n}
-          file.write %Q{  - shell: cURL\n}
-          file.write %Q{---\n\n}
-
-          file.write configuration.api_explanation if configuration.api_explanation
+          file.write markup_index_class.new(index, configuration).render
 
           IndexHelper.sections(index.examples, @configuration).each do |section|
 

--- a/lib/rspec_api_documentation/writers/slate_writer.rb
+++ b/lib/rspec_api_documentation/writers/slate_writer.rb
@@ -28,6 +28,8 @@ module RspecApiDocumentation
           file.write %Q{  - shell: cURL\n}
           file.write %Q{---\n\n}
 
+          file.write configuration.api_explanation if configuration.api_explanation
+
           IndexHelper.sections(index.examples, @configuration).each do |section|
 
             file.write "# #{section[:resource_name]}\n\n"

--- a/spec/writers/slate_writer_spec.rb
+++ b/spec/writers/slate_writer_spec.rb
@@ -22,7 +22,7 @@ describe RspecApiDocumentation::Writers::SlateWriter do
       FakeFS do
         template_dir = File.join(configuration.template_path, "rspec_api_documentation")
         FileUtils.mkdir_p(template_dir)
-        File.open(File.join(template_dir, "markdown_index.mustache"), "w+") { |f| f << "{{ mustache }}" }
+        File.open(File.join(template_dir, "slate_index.mustache"), "w+") { |f| f << "{{ mustache }}" }
         FileUtils.mkdir_p(configuration.docs_dir)
 
         writer.write

--- a/templates/rspec_api_documentation/slate_index.mustache
+++ b/templates/rspec_api_documentation/slate_index.mustache
@@ -1,0 +1,8 @@
+---
+title: {{ api_name }}
+language_tabs:
+  - json: JSON
+  - shell: cURL
+---
+
+{{{ api_explanation }}}


### PR DESCRIPTION
Currently, the Slate formatter (introduced in #282) does not provide a means for common content to be included. This change extracts the YAML front matter and title to its own template. It also adds the API explanation field into the template.

Note that this allows #294 to be resolved because the YAML front matter can be updated in your own custom template.