### PR TITLE
Remove special chars from dirnames

### DIFF
--- a/lib/rspec_api_documentation/views/markup_example.rb
+++ b/lib/rspec_api_documentation/views/markup_example.rb
@@ -3,6 +3,8 @@ require 'mustache'
 module RspecApiDocumentation
   module Views
     class MarkupExample < Mustache
+      SPECIAL_CHARS = /[<>:"\/\\|?*]/.freeze
+
       def initialize(example, configuration)
         @example = example
         @host = configuration.curl_host
@@ -19,12 +21,11 @@ module RspecApiDocumentation
       end
 
       def dirname
-        resource_name.to_s.downcase.gsub(/\s+/, '_').gsub(":", "_")
+        sanitize(resource_name.to_s.downcase)
       end
 
       def filename
-        special_chars = /[<>:"\/\\|?*]/
-        basename = description.downcase.gsub(/\s+/, '_').gsub(special_chars, '')
+        basename = sanitize(description.downcase)
         basename = Digest::MD5.new.update(description).to_s if basename.blank?
         "#{basename}.#{extension}"
       end
@@ -86,6 +87,10 @@ module RspecApiDocumentation
 
       def content_type(headers)
         headers && headers.fetch("Content-Type", nil)
+      end
+
+      def sanitize(name)
+        name.gsub(/\s+/, '_').gsub(SPECIAL_CHARS, '')
       end
     end
   end

--- a/spec/views/html_example_spec.rb
+++ b/spec/views/html_example_spec.rb
@@ -28,6 +28,14 @@ describe RspecApiDocumentation::Views::HtmlExample do
     end
   end
 
+  context "when resource name contains special characters for Windows OS" do
+    let(:metadata) { { :resource_name => 'foo<>:"/\|?*bar' } }
+
+    it "removes them" do
+      expect(html_example.dirname).to eq("foobar")
+    end
+  end
+
   describe "multi-character example name" do
     let(:metadata) { { :resource_name => "オーダ" } }
     let(:label) { "Coffee / Teaが順番で並んでいること" }


### PR DESCRIPTION
Using special characters in resource names may break git clone on Windows when API docs are stored in repo. This is mostly because some of these characters are considered as file separators.

The solution is to remove all characters listed here: https://msdn.microsoft.com/en-ca/library/windows/desktop/aa365247(v=vs.85).aspx#naming_conventions

Note: the same issue was fixed previously, but for `filename` only: https://github.com/zipmark/rspec_api_documentation/pull/300

