### PR TITLE
Slate resource explanation

### DIFF
--- a/features/slate_documentation.feature
+++ b/features/slate_documentation.feature
@@ -215,9 +215,10 @@ Feature: Generate Slate documentation from test examples
     """
     # Orders
 
+    An Order represents an amount of money to be paid
+
     ## Creating an order
 
-    An Order represents an amount of money to be paid
 
     ### Request
 

--- a/features/slate_documentation.feature
+++ b/features/slate_documentation.feature
@@ -57,6 +57,7 @@ Feature: Generate Slate documentation from test examples
       end
 
       resource 'Orders' do
+        explanation "An Order represents an amount of money to be paid"
         get '/orders' do
           response_field :page, "Current page"
 
@@ -216,6 +217,7 @@ Feature: Generate Slate documentation from test examples
 
     ## Creating an order
 
+    An Order represents an amount of money to be paid
 
     ### Request
 

--- a/lib/rspec_api_documentation/writers/slate_writer.rb
+++ b/lib/rspec_api_documentation/writers/slate_writer.rb
@@ -26,6 +26,7 @@ module RspecApiDocumentation
           IndexHelper.sections(index.examples, @configuration).each do |section|
 
             file.write "# #{section[:resource_name]}\n\n"
+            file.write "#{section[:resource_explanation]}\n\n"
             section[:examples].sort_by!(&:description) unless configuration.keep_source_order
 
             section[:examples].each do |example|

--- a/lib/rspec_api_documentation/writers/slate_writer.rb
+++ b/lib/rspec_api_documentation/writers/slate_writer.rb
@@ -24,10 +24,8 @@ module RspecApiDocumentation
           file.write markup_index_class.new(index, configuration).render
 
           IndexHelper.sections(index.examples, @configuration).each do |section|
-
             file.write "# #{section[:resource_name]}\n\n"
             file.write "#{section[:resource_explanation]}\n\n"
-            section[:examples].sort_by!(&:description) unless configuration.keep_source_order
 
             section[:examples].each do |example|
               markup_example = markup_example_class.new(example, configuration)


### PR DESCRIPTION
Resource-level [explanations](https://github.com/zipmark/rspec_api_documentation#explanation) were not included in the Slate formatter. This restores resource level explanations under resource sections.