### PR TITLE
API Blueprint view object respects required: false for parameters now

### DIFF
--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -354,12 +354,12 @@ Feature: Generate API Blueprint documentation from test examples
 
     + Parameters
       + id: 1 (required, string) - Order id
-      + optional
+      + optional (optional)
 
     + Attributes (object)
       + name: a name (required) - The order name
-      + amount
-      + description: a description (string) - The order description
+      + amount (optional)
+      + description: a description (optional, string) - The order description
 
     ### Deletes a specific order [DELETE]
 

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -74,7 +74,11 @@ module RspecApiDocumentation
           .uniq { |property| property[:name] }
           .map do |property|
             properties = []
-            properties << "optional"      if !property[:required]
+            if property[:required] == true
+              properties << 'required'
+            else
+              properties << 'optional'
+            end
             properties << property[:type] if property[:type]
             if properties.count > 0
               property[:properties_description] = properties.join(", ")

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -74,7 +74,7 @@ module RspecApiDocumentation
           .uniq { |property| property[:name] }
           .map do |property|
             properties = []
-            properties << "required"      if property[:required]
+            properties << "optional"      if !property[:required]
             properties << property[:type] if property[:type]
             if properties.count > 0
               property[:properties_description] = properties.join(", ")

--- a/spec/views/api_blueprint_index_spec.rb
+++ b/spec/views/api_blueprint_index_spec.rb
@@ -143,7 +143,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
         }, {
           name: "option",
           description: nil,
-          properties_description: nil
+          properties_description: 'optional'
         }]
         expect(post_route_with_optionals[:has_attributes?]).to eq false
         expect(post_route_with_optionals[:attributes]).to eq []
@@ -159,7 +159,7 @@ describe RspecApiDocumentation::Views::ApiBlueprintIndex do
           required: false,
           name: "description",
           description: nil,
-          properties_description: nil
+          properties_description: "optional"
         }]
       end
     end


### PR DESCRIPTION
## What Changed
API Blueprint renderer will not flag parameters as `optional` if `required: false` is set

## Why
By default, API Blueprint [considers all parameters as required](https://apiblueprint.org/documentation/specification.html#def-uriparameters-section#uri-parameters-section). This change adjusts the API Blueprint view object's logic to set "optional" on a parameter if `required: false` is set.  

*note*: if this has the potential to be merged in. I will gladly add test and offer further explanation if needed