### PR TITLE
Remove HTML pre tags from Markdown writer's template

### DIFF
--- a/templates/rspec_api_documentation/markdown_example.mustache
+++ b/templates/rspec_api_documentation/markdown_example.mustache
@@ -37,46 +37,56 @@
 ### Request
 
 #### Headers
-
-<pre>{{ request_headers_text }}</pre>
+```
+{{ request_headers_text }}
+```
 
 #### Route
-
-<pre>{{ request_method }} {{ request_path }}</pre>
+```
+{{ request_method }} {{ request_path }}
+```
 {{# request_query_parameters_text }}
 
 #### Query Parameters
-
-<pre>{{ request_query_parameters_text }}</pre>
+```
+{{ request_query_parameters_text }}
+```
 {{/ request_query_parameters_text }}
 {{# request_body }}
 
 #### Body
-
-<pre>{{{ request_body }}}</pre>
+```
+{{{ request_body }}}
+```
 {{/ request_body }}
 {{# curl }}
 
 #### cURL
-
-<pre class="request">{{ curl }}</pre>
+```
+{{ curl }}
+```
 {{/ curl }}
 
 {{# response_status }}
+
 ### Response
 
 #### Headers
-
-<pre>{{ response_headers_text }}</pre>
+```
+{{ response_headers_text }}
+```
 
 #### Status
-
-<pre>{{ response_status }} {{ response_status_text}}</pre>
+```
+{{ response_status }} {{ response_status_text}}
+```
 
 {{# response_body }}
 #### Body
+```
+{{{ response_body }}}
+```
 
-<pre>{{{ response_body }}}</pre>
 {{/ response_body }}
 {{/ response_status }}
 {{/ requests }}


### PR DESCRIPTION
Hi guys. I've been playing with VuePress and it works fine with rspec_api_documentation, but pre tags in the Markdown's template break the display of sections. Here are the changes I made in the template to fix it.