### PR TITLE
Fixes API Blueprint route's always grouping

### DIFF
--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -8,7 +8,7 @@ module RspecApiDocumentation
 
       def sections
         super.map do |section|
-          routes = section[:examples].group_by { |e| "#{e.route_uri}#{e.route_optionals}" }.map do |route, examples|
+          routes = section[:examples].group_by { |e| "#{e.route_uri}#{e.route_optionals}#{e.route_name}" }.map do |route, examples|
             attrs  = fields(:attributes, examples)
             params = fields(:parameters, examples)
 


### PR DESCRIPTION
While using the API Blueprint formatter, I discovered that this gem will always group your endpoint documentation by route no matter what. This isn't always desirable as some users may want to have a bit more control over how these requests are grouped in documentation.

I attempted to write specs:

```ruby
route '/resource/:id', 'Read Resource' do
  get 'fetch resource with specified id' do
    #...
  end
end

route '/resource/:id', 'Update Resource' do
  patch 'update resource with specified id' do
    #...
  end
end
```

as

```ruby
get '/resource/:id' do
  #...
end

post '/resource/:id' do
  #...
end
```

But the test suite will fail with `--format RspecApiDocumentation::ApiFormatter` format because no `route_uri` is set.

I would think that these requests would only be grouped together when they are in the same `route` block but that is not the case. I attempted to adjust functionality to work like that but didn't get very far.

How would you feel about a change like this??? If you want multiple endpoint groupped together they must all have the same route_uri, route_optionals, and route_name?

This means that you can group endpoints as follows

```ruby
route '/resource/:id', 'Read Resource' do
  get 'fetch resource with specified id' do
    #...
  end
end

route '/resource/:id', 'Modify Resource' do
  patch 'update resource with specified id' do
    #...
  end
end

route '/resource/:id', 'Modify Resource' do
  delete 'delete resource with specified id' do
    #...
  end
end
```

This will put the `get` call into it's own "Read Resource" group and the `patch`/`delete` calls into their own "Modify Resource" group.

Another options would be to set something like a "route id" or some kind of unique identifier on the example options [somewhere around here](https://github.com/zipmark/rspec_api_documentation/blob/master/lib/rspec_api_documentation/dsl/resource.rb#L50-L52).

Thoughts? I have no issue updating documentation once we agree on an approach.