### PR TITLE
Fix: Issues #191 #402 and #403: Add example property and remove duplicated parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,8 @@ This [format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/
     
 * Several new options on `parameter` helper.
 
-    - `with_example: true`. This option will adjust your description of the parameter with the passed value.
+    - `with_example: true`. This option will adjust your example of the parameter with the passed value.
+    - `example: <value>`. Will provide a example value for the parameter.
     - `default: <value>`. Will provide a default value for the parameter.
     - `minimum: <integer>`. Will setup upper limit for your parameter. 
     - `maximum: <integer>`. Will setup lower limit for your parameter.

--- a/features/open_api.feature
+++ b/features/open_api.feature
@@ -424,17 +424,18 @@ Feature: Generate Open API Specification from test examples
               {
                 "name": "one_level_arr",
                 "in": "query",
-                "description": " one level arr\nEg, `[\"value1\", \"value2\"]`",
+                "description": " one level arr",
                 "required": false,
                 "type": "array",
                 "items": {
                   "type": "string"
-                }
+                },
+                "example": ["value1", "value2"]
               },
               {
                 "name": "two_level_arr",
                 "in": "query",
-                "description": " two level arr\nEg, `[[5.1, 3.0], [1.0, 4.5]]`",
+                "description": " two level arr",
                 "required": false,
                 "type": "array",
                 "items": {
@@ -442,7 +443,8 @@ Feature: Generate Open API Specification from test examples
                   "items": {
                     "type": "number"
                   }
-                }
+                },
+                "example": [[5.1, 3.0], [1.0, 4.5]]
               }
             ],
             "responses": {

--- a/features/open_api.feature
+++ b/features/open_api.feature
@@ -430,7 +430,10 @@ Feature: Generate Open API Specification from test examples
                 "items": {
                   "type": "string"
                 },
-                "example": ["value1", "value2"]
+                "example": [
+                  "value1",
+                  "value2"
+                ]
               },
               {
                 "name": "two_level_arr",
@@ -444,7 +447,16 @@ Feature: Generate Open API Specification from test examples
                     "type": "number"
                   }
                 },
-                "example": [[5.1, 3.0], [1.0, 4.5]]
+                "example": [
+                  [
+                    5.1,
+                    3.0
+                  ],
+                  [
+                    1.0,
+                    4.5
+                  ]
+                ]
               }
             ],
             "responses": {

--- a/lib/rspec_api_documentation/open_api/parameter.rb
+++ b/lib/rspec_api_documentation/open_api/parameter.rb
@@ -16,18 +16,9 @@ module RspecApiDocumentation
       add_setting :minimum
       add_setting :maximum
       add_setting :enum
-
-      def description_with_example
-        str = description_without_example.dup || ''
-        if with_example && value
-          str << "\n" unless str.empty?
-          str << "Eg, `#{value}`"
-        end
-        str
-      end
+      add_setting :example, :default => lambda { |parameter| parameter.with_example ? parameter.value : nil }
 
       alias_method :description_without_example, :description
-      alias_method :description, :description_with_example
     end
   end
 end

--- a/lib/rspec_api_documentation/writers/open_api_writer.rb
+++ b/lib/rspec_api_documentation/writers/open_api_writer.rb
@@ -156,8 +156,10 @@ module RspecApiDocumentation
       end
 
       def extract_parameters(example)
-        extract_known_parameters(example.extended_parameters.select { |p| !p[:in].nil? }) +
-          extract_unknown_parameters(example, example.extended_parameters.select { |p| p[:in].nil? })
+        parameters = example.extended_parameters.uniq { |parameter| parameter[:name] }
+
+        extract_known_parameters(parameters.select { |p| !p[:in].nil? }) +
+          extract_unknown_parameters(example, parameters.select { |p| p[:in].nil? })
       end
 
       def extract_parameter(opts)
@@ -170,6 +172,7 @@ module RspecApiDocumentation
           value:        opts[:value],
           with_example: opts[:with_example],
           default:      opts[:default],
+          example:      opts[:example],
         ).tap do |elem|
           if elem.type == :array
             elem.items = opts[:items] || OpenApi::Helper.extract_items(opts[:value][0], { minimum: opts[:minimum], maximum: opts[:maximum], enum: opts[:enum] })


### PR DESCRIPTION
**Before this fix**

* the params example are presented in plain text into `description` (#191, #403)
* the rspec_api_documentation duplicates parameters in path (#393, #402)

**After the fix**

* rspec_api_docs now uses [swagger examples](https://swagger.io/docs/specification/2-0/adding-examples/) in open_api;
* rspec_api_docs presents correctly the queries and path parameters.