### PR TITLE
Added a fix for the value mapping of an array of objects

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint/params.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint/params.rb
@@ -30,6 +30,16 @@ module RspecApiDocumentation
             unless p[:value]
               cur = extra_params
               [*p[:scope]].each { |scope| cur = cur && (cur[scope.to_sym] || cur[scope.to_s]) }
+
+              # When the current parameter is an array of objects, we use the
+              # first one for the value and add a scope indicator. The
+              # resulting parameter name looks like +props[pictures][][id]+
+              # this.
+              if cur.is_a?(Array) && cur.first.is_a?(Hash)
+                cur = cur.first
+                param[:scope] << ''
+              end
+
               p[:value] = cur && (cur[p[:name].to_s] || cur[p[:name].to_sym])
             end
             p


### PR DESCRIPTION
**- What is it good for**

I stumbled over the version 5 to 6 upgrade issue (https://github.com/zipmark/rspec_api_documentation/issues/398) and this is an approach to solve the issue. 

**- What I did**

I debugged the `cur` property to be an array and the `p[:name]` access resulted in an `TypeError: no implicit conversion of String into Integer`. Now we detect this situation and pick the first object of the array. Furthermore we add an additional empty string to the `scopes` array as an indicator. This results in parameter names like this: `props[pictures][][id]`.

**- A picture of a cute animal (not mandatory but encouraged)**

![images 1](https://user-images.githubusercontent.com/2496275/46530365-c5453a00-c899-11e8-8b9e-0b66a6ad5d37.jpeg)