### PR TITLE
Update readme configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Consider adding a viewer to enhance the generated documentation. By itself rspec
 
     gem 'apitome'
 
-#### spec/spec_helper.rb
+#### config/initializers/rspec_api_documentation.rb
 
 ```ruby
 RspecApiDocumentation.configure do |config|


### PR DESCRIPTION
Setup the configuration under config/initializers/rspec_api_documentation.rb 
instead of spec/spec_helper.rb since the latter does't work.