### PR TITLE
Replace child_class with hash like schemas in open_api

### DIFF
--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -58,18 +58,14 @@ module RspecApiDocumentation
     autoload :Info
     autoload :Contact
     autoload :License
-    autoload :Paths
     autoload :Path
     autoload :Tag
     autoload :Operation
     autoload :Parameter
-    autoload :Responses
     autoload :Response
     autoload :Example
-    autoload :Headers
     autoload :Header
     autoload :Schema
-    autoload :SecurityDefinitions
     autoload :SecuritySchema
   end
 

--- a/lib/rspec_api_documentation.rb
+++ b/lib/rspec_api_documentation.rb
@@ -63,7 +63,6 @@ module RspecApiDocumentation
     autoload :Operation
     autoload :Parameter
     autoload :Response
-    autoload :Example
     autoload :Header
     autoload :Schema
     autoload :SecuritySchema

--- a/lib/rspec_api_documentation/open_api/example.rb
+++ b/lib/rspec_api_documentation/open_api/example.rb
@@ -1,7 +1,0 @@
-module RspecApiDocumentation
-  module OpenApi
-    class Example < Node
-      CHILD_CLASS = true
-    end
-  end
-end

--- a/lib/rspec_api_documentation/open_api/headers.rb
+++ b/lib/rspec_api_documentation/open_api/headers.rb
@@ -1,7 +1,0 @@
-module RspecApiDocumentation
-  module OpenApi
-    class Headers < Node
-      CHILD_CLASS = Header
-    end
-  end
-end

--- a/lib/rspec_api_documentation/open_api/node.rb
+++ b/lib/rspec_api_documentation/open_api/node.rb
@@ -1,12 +1,6 @@
 module RspecApiDocumentation
   module OpenApi
     class Node
-      # this is used to define class of incoming option attribute
-      # If +false+ then do not create new setting
-      # If +true+ then create new setting with raw passed value
-      # If RspecApiDocumentation::OpenApi::Node then create new setting and wrap it in this class
-      CHILD_CLASS = false
-
       # This attribute allow us to hide some of children through configuration file
       attr_accessor :hide
 
@@ -49,8 +43,6 @@ module RspecApiDocumentation
                 value
               end
             assign_setting(name, converted)
-          elsif self.class::CHILD_CLASS
-            add_setting name, :value => self.class::CHILD_CLASS === true ? value : self.class::CHILD_CLASS.new(value)
           else
             public_send("#{name}=", value) if respond_to?("#{name}=")
           end
@@ -98,7 +90,7 @@ module RspecApiDocumentation
             tmp = value.select { |v| !v.hide }.map { |v| v.as_json }
             hash[name] = tmp unless tmp.empty?
           when value.is_a?(Hash) && value.values[0].is_a?(Node)
-            hash[name] = Hash[value.map { |k, v| [k, v.as_json] }]
+            hash[name] = Hash[value.select { |k, v| !v.hide }.map { |k, v| [k, v.as_json] }]
           else
             hash[name] = value
           end unless value.nil?

--- a/lib/rspec_api_documentation/open_api/operation.rb
+++ b/lib/rspec_api_documentation/open_api/operation.rb
@@ -3,13 +3,13 @@ module RspecApiDocumentation
     class Operation < Node
       add_setting :tags, :default => []
       add_setting :summary
-      add_setting :description, :default => ''
+      add_setting :description
       add_setting :externalDocs
       add_setting :operationId
       add_setting :consumes
       add_setting :produces
       add_setting :parameters, :default => [], :schema => [Parameter]
-      add_setting :responses, :required => true, :schema => Responses
+      add_setting :responses, :required => true, :schema => { String => Response }
       add_setting :schemes
       add_setting :deprecated, :default => false
       add_setting :security

--- a/lib/rspec_api_documentation/open_api/paths.rb
+++ b/lib/rspec_api_documentation/open_api/paths.rb
@@ -1,7 +1,0 @@
-module RspecApiDocumentation
-  module OpenApi
-    class Paths < Node
-      CHILD_CLASS = Path
-    end
-  end
-end

--- a/lib/rspec_api_documentation/open_api/response.rb
+++ b/lib/rspec_api_documentation/open_api/response.rb
@@ -3,8 +3,8 @@ module RspecApiDocumentation
     class Response < Node
       add_setting :description, :required => true, :default => 'Successful operation'
       add_setting :schema, :schema => Schema
-      add_setting :headers, :schema => Headers
-      add_setting :examples, :schema => Example
+      add_setting :headers, :schema => { "" => Header }
+      add_setting :examples
     end
   end
 end

--- a/lib/rspec_api_documentation/open_api/response.rb
+++ b/lib/rspec_api_documentation/open_api/response.rb
@@ -3,7 +3,7 @@ module RspecApiDocumentation
     class Response < Node
       add_setting :description, :required => true, :default => 'Successful operation'
       add_setting :schema, :schema => Schema
-      add_setting :headers, :schema => { "" => Header }
+      add_setting :headers, :schema => { String => Header }
       add_setting :examples
     end
   end

--- a/lib/rspec_api_documentation/open_api/responses.rb
+++ b/lib/rspec_api_documentation/open_api/responses.rb
@@ -1,9 +1,0 @@
-module RspecApiDocumentation
-  module OpenApi
-    class Responses < Node
-      CHILD_CLASS = Response
-
-      add_setting :default, :default => lambda { |responses| responses.existing_settings.size > 1 ? nil : Response.new }
-    end
-  end
-end

--- a/lib/rspec_api_documentation/open_api/root.rb
+++ b/lib/rspec_api_documentation/open_api/root.rb
@@ -8,7 +8,7 @@ module RspecApiDocumentation
       add_setting :schemes, :default => %w(http https)
       add_setting :consumes, :default => %w(application/json application/xml)
       add_setting :produces, :default => %w(application/json application/xml)
-      add_setting :paths, :default => Paths.new, :required => true, :schema => Paths
+      add_setting :paths, :default => {}, :required => true, :schema => { "" => Path }
       add_setting :definitions
       add_setting :parameters
       add_setting :responses

--- a/lib/rspec_api_documentation/open_api/root.rb
+++ b/lib/rspec_api_documentation/open_api/root.rb
@@ -8,11 +8,11 @@ module RspecApiDocumentation
       add_setting :schemes, :default => %w(http https)
       add_setting :consumes, :default => %w(application/json application/xml)
       add_setting :produces, :default => %w(application/json application/xml)
-      add_setting :paths, :default => {}, :required => true, :schema => { "" => Path }
+      add_setting :paths, :default => {}, :required => true, :schema => { String => Path }
       add_setting :definitions
       add_setting :parameters
       add_setting :responses
-      add_setting :securityDefinitions, :schema => SecurityDefinitions
+      add_setting :securityDefinitions, :schema => { String => SecuritySchema }
       add_setting :security
       add_setting :tags, :default => [], :schema => [Tag]
       add_setting :externalDocs

--- a/lib/rspec_api_documentation/open_api/security_definitions.rb
+++ b/lib/rspec_api_documentation/open_api/security_definitions.rb
@@ -1,7 +1,0 @@
-module RspecApiDocumentation
-  module OpenApi
-    class SecurityDefinitions < Node
-      CHILD_CLASS = SecuritySchema
-    end
-  end
-end

--- a/spec/open_api/root_spec.rb
+++ b/spec/open_api/root_spec.rb
@@ -8,7 +8,6 @@ describe RspecApiDocumentation::OpenApi::Root do
 
   describe "default settings" do
     class RspecApiDocumentation::OpenApi::Info; end
-    class RspecApiDocumentation::OpenApi::Paths; end
 
     its(:swagger) { should == '2.0' }
     its(:info) { should be_a(RspecApiDocumentation::OpenApi::Info) }
@@ -17,7 +16,6 @@ describe RspecApiDocumentation::OpenApi::Root do
     its(:schemes) { should == %w(http https) }
     its(:consumes) { should == %w(application/json application/xml) }
     its(:produces) { should == %w(application/json application/xml) }
-    its(:paths) { should be_a(RspecApiDocumentation::OpenApi::Paths) }
     its(:definitions) { should be_nil }
     its(:parameters) { should be_nil }
     its(:responses) { should be_nil }

--- a/spec/open_api/root_spec.rb
+++ b/spec/open_api/root_spec.rb
@@ -19,6 +19,7 @@ describe RspecApiDocumentation::OpenApi::Root do
     its(:definitions) { should be_nil }
     its(:parameters) { should be_nil }
     its(:responses) { should be_nil }
+    its(:paths) { should == {} }
     its(:securityDefinitions) { should be_nil }
     its(:security) { should be_nil }
     its(:tags) { should == [] }


### PR DESCRIPTION
To make transition to open_api 3.0 smoother, I am removing child_class logic and instead making Hash like schema work.

This will save a lot of empty classes with only CHILD_CLASS variable like `Responses`, `Paths`, `Headers`, etc.

Note: This doesn't change openapi document output.