### PR TITLE
Add parameter/attribute defaults, enums and annotations for API Blueprint

### DIFF
--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -115,6 +115,11 @@ Feature: Generate API Blueprint documentation from test examples
           attribute :name, 'The order name', required: true, :example => 'a name'
           attribute :amount, required: false
           attribute :description, 'The order description', type: 'string', required: false, example: "a description"
+          attribute :category, 'The order category', type: 'string', required: false, default: 'normal', enum: %w[normal priority]
+          attribute :metadata, 'The order metadata', type: 'json', required: false, annotation: <<-MARKDOWN
+    + instructions (optional, string)
+    + notes (optional, string)
+          MARKDOWN
 
           get 'Returns a single order' do
             explanation "This is used to return orders."
@@ -360,6 +365,14 @@ Feature: Generate API Blueprint documentation from test examples
       + name: a name (required) - The order name
       + amount (optional)
       + description: a description (optional, string) - The order description
+      + category (optional, string) - The order category
+          + Default: `normal`
+          + Members
+              + `normal`
+              + `priority`
+      + metadata (optional, json) - The order metadata
+          + instructions (optional, string)
+          + notes (optional, string)
 
     ### Deletes a specific order [DELETE]
 

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -89,6 +89,8 @@ module RspecApiDocumentation
             property[:has_default?] = true if property[:default]
             property[:has_enum?] = true if property[:enum]
 
+            property[:annotations] = property[:annotation].lines.map(&:chomp) if property[:annotation]
+
             property[:description] = nil if description_blank?(property)
             property
           end

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -86,6 +86,9 @@ module RspecApiDocumentation
               property[:properties_description] = nil
             end
 
+            property[:has_default?] = true if property[:default]
+            property[:has_enum?] = true if property[:enum]
+
             property[:description] = nil if description_blank?(property)
             property
           end

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -43,6 +43,9 @@ explanation: {{ explanation }}
 + Attributes (object)
 {{# attributes }}
   + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+  {{# annotations }}
+      {{ . }}
+  {{/ annotations }}
 {{/ attributes }}
 {{/ has_attributes? }}
 {{# http_methods }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -36,6 +36,9 @@ explanation: {{ explanation }}
           + `{{.}}`
         {{/ enum}}
       {{/ has_enum?}}
+  {{# annotations }}
+      {{ . }}
+  {{/ annotations }}
 {{/ parameters }}
 {{/ has_parameters? }}
 {{# has_attributes? }}
@@ -43,6 +46,15 @@ explanation: {{ explanation }}
 + Attributes (object)
 {{# attributes }}
   + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+      {{# has_default?}}
+      + Default: `{{default}}`
+      {{/ has_default?}}
+      {{# has_enum?}}
+      + Members
+        {{# enum}}
+          + `{{.}}`
+        {{/ enum}}
+      {{/ has_enum?}}
   {{# annotations }}
       {{ . }}
   {{/ annotations }}

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -27,6 +27,15 @@ explanation: {{ explanation }}
 + Parameters
 {{# parameters }}
   + {{ name }}{{# example }}: {{ example }}{{/ example }}{{# properties_description }} ({{ properties_description }}){{/ properties_description }}{{# description }} - {{ description }}{{/ description }}
+      {{# has_default?}}
+      + Default: `{{default}}`
+      {{/ has_default?}}
+      {{# has_enum?}}
+      + Members
+        {{# enum}}
+          + `{{.}}`
+        {{/ enum}}
+      {{/ has_enum?}}
 {{/ parameters }}
 {{/ has_parameters? }}
 {{# has_attributes? }}


### PR DESCRIPTION
This will include the `default` and `enum` metadata when rendering parameters or attributes.

The following parameter declaration:

```
parameter :status, 'Status', type: :string, default: 'completed', enum: %w[pending complete]
```

Would be rendered as:

```
+ Parameters
  + status (optional, string) - Status
      + Default: `complete`
      + Members
          + `pending`
          + `complete`
```

I've also added the ability to add raw API Blueprint annotations for object attributes, which is useful when describing JSONAPI payloads:

```
attribute :data, type: :object, required: true, annotation: <<~MARKDOWN
    + attributes (required, object)
        + name (required, string)
MARKDOWN
```

This will be rendered to:

```
+ Attributes (object)
  + data (required, object) - 
      + attributes (required, object)
          + name (required, string)
```