### PR TITLE
Encode body requests

### DIFF
--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -100,7 +100,7 @@
 
           {{# request_body }}
             <h4>Body</h4>
-            <pre class="request body">{{{ request_body }}}</pre>
+            <pre class="request body">{{ request_body }}</pre>
           {{/ request_body }}
 
           {{# curl }}


### PR DESCRIPTION
Hi guys,

I had a request to write a spec that posts XML as a body. 
In this case, I have to use `raw_post` and spec will look like:
```
  post "/api" do
    let(:raw_post) { { param1: 1, param2: 2 }.to_xml(root: :order) }
    example_request 'Getting a list of orders' do
      expect(status).to eq(200)
    end
  end
```
after running `rake docs:generate`, generated XML `request_body`  won't be encode in the output 😭 :
https://github.com/zipmark/rspec_api_documentation/blob/57ece9131cb5272aeeae49e06ef7d8e572e84310/templates/rspec_api_documentation/html_example.mustache#L103
```
<order><param1>1</param1><param2>2</param2></order>
```
but expected to be encoded as response body:
https://github.com/zipmark/rspec_api_documentation/blob/57ece9131cb5272aeeae49e06ef7d8e572e84310/templates/rspec_api_documentation/html_example.mustache#L121
```
&lt;order&gt;&lt;param1&gt;1&lt;/param1&gt;&lt;param2&gt;2&lt;/param2&gt;&lt;/order&gt;
```
Another example:
![](https://www.evernote.com/l/ABmUH262YexG644ejm-_9MJ8hZ2NiM009Y4B/image.png)