### PR TITLE
Refactor .should

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ resource "Orders" do
     example "Listing orders" do
       do_request
 
-      status.should == 200
+      expect(status).to eq 200
     end
   end
 end


### PR DESCRIPTION
`should` and `should_not` work by being added to every object. However, RSpec does not own every object and cannot ensure they work consistently on every object. In particular, they can lead to surprising failures when used with BasicObject-subclassed proxy objects.

`expect` avoids these problems altogether by not needing to be available on all objects.