### PR TITLE
Add `api_host_name` to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ RspecApiDocumentation.configure do |config|
 
   # Change the name of the API on index pages
   config.api_name = "API Documentation"
+
+  # HOST key used in apib files metadata, allowing to enable production
+  # proxy at Apiary https://help.apiary.io/faq/enable_production_proxy/
+  config.api_host_name = nil
   
   # Change the description of the API on index pages
   config.api_explanation = "API Description"

--- a/features/api_blueprint_documentation.feature
+++ b/features/api_blueprint_documentation.feature
@@ -64,6 +64,7 @@ Feature: Generate API Blueprint documentation from test examples
       RspecApiDocumentation.configure do |config|
         config.app = App
         config.api_name = "Example API"
+        config.api_host_name = "example.org"
         config.api_explanation = "Example API Description"
         config.format = :api_blueprint
         config.request_body_formatter = :json
@@ -249,6 +250,8 @@ Feature: Generate API Blueprint documentation from test examples
     Then the file "doc/api/index.apib" should contain exactly:
     """
     FORMAT: 1A
+    HOST: example.org
+
     # Example API
 
     # Group Instructions

--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -83,6 +83,7 @@ module RspecApiDocumentation
     add_setting :curl_host, :default => nil
     add_setting :keep_source_order, :default => false
     add_setting :api_name, :default => "API Documentation"
+    add_setting :api_host_name, :default => nil
     add_setting :api_explanation, :default => nil
     add_setting :io_docs_protocol, :default => "http"
     add_setting :request_headers_to_include, :default => nil

--- a/lib/rspec_api_documentation/views/api_blueprint_index.rb
+++ b/lib/rspec_api_documentation/views/api_blueprint_index.rb
@@ -1,6 +1,8 @@
 module RspecApiDocumentation
   module Views
     class ApiBlueprintIndex < MarkupIndex
+      delegate :api_host_name, to: :@configuration, prefix: false
+
       def initialize(index, configuration)
         super
         self.template_name = "rspec_api_documentation/api_blueprint_index"
@@ -41,6 +43,10 @@ module RspecApiDocumentation
         @index.examples.map do |example|
           ApiBlueprintExample.new(example, @configuration)
         end
+      end
+
+      def has_host_metadata?
+        api_host_name.present?
       end
 
       private

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -52,6 +52,7 @@ describe RspecApiDocumentation::Configuration do
     its(:curl_host) { should be_nil }
     its(:keep_source_order) { should be_falsey }
     its(:api_name) { should == "API Documentation" }
+    its(:api_host_name) { should be_nil }
     its(:api_explanation) { should be_nil }
     its(:client_method) { should == :client }
     its(:io_docs_protocol) { should == "http" }

--- a/templates/rspec_api_documentation/api_blueprint_index.mustache
+++ b/templates/rspec_api_documentation/api_blueprint_index.mustache
@@ -1,4 +1,8 @@
 FORMAT: 1A
+{{# has_host_metadata? }}
+HOST: {{ api_host_name }}
+{{/ has_host_metadata? }}
+
 # {{ api_name }}
 {{# sections }}
 


### PR DESCRIPTION
`api_host_name` is an option used with API Blueprint format to define `HOST` key metadata, which is supported by Apiary to setup a production proxy (https://help.apiary.io/faq/enable_production_proxy/)