### PR TITLE
Fixes missing JsonIndex#section_hash exception when using :append_json

### DIFF
--- a/lib/rspec_api_documentation/writers/json_iodocs_writer.rb
+++ b/lib/rspec_api_documentation/writers/json_iodocs_writer.rb
@@ -37,14 +37,18 @@ module RspecApiDocumentation
 
       def as_json(opts = nil)
         sections.inject({:endpoints => []}) do |h, section|
-          h[:endpoints].push(
-            :name => section[:resource_name],
-            :methods => section[:examples].map do |example|
-              example.as_json(opts)
-            end
-          )
+          h[:endpoints].push(section_hash(section, opts))
           h
         end
+      end
+
+      def section_hash(section, opts = nil)
+        {
+          :name => section[:resource_name],
+          :methods => section[:examples].map do |example|
+            example.as_json(opts)
+          end
+        }
       end
     end
 


### PR DESCRIPTION
I've been getting doc generation failures when using the `config.format = :append_json` option:

```
Traceback (most recent call last):
        26: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/exe/rspec:4:in `<main>'
        25: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:45:in `invoke'
        24: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:71:in `run'
        23: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:87:in `run'
        22: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/runner.rb:110:in `run_specs'
        21: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:76:in `report'
        20: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:166:in `finish'
        19: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:186:in `close_after'
        18: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:167:in `block in finish'
        17: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:194:in `stop'
        16: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:200:in `notify'
        15: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:200:in `each'
        14: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec-core-3.8.0/lib/rspec/core/reporter.rb:201:in `block in notify'
        13: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/api_formatter.rb:38:in `stop'
        12: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/api_formatter.rb:38:in `each'
        11: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/api_documentation.rb:28:in `write'
        10: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/api_documentation.rb:28:in `each'
         9: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/api_documentation.rb:29:in `block in write'
         8: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/writer.rb:13:in `write'
         7: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/append_json_writer.rb:11:in `write'
         6: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/append_json_writer.rb:11:in `open'
         5: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/append_json_writer.rb:12:in `block in write'
         4: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/formatter.rb:6:in `to_json'
         3: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/append_json_writer.rb:30:in `as_json'
         2: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/append_json_writer.rb:30:in `inject'
         1: from /Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/append_json_writer.rb:30:in `each'
/Users/michaelzemel/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/rspec_api_documentation-6.1.0/lib/rspec_api_documentation/writers/append_json_writer.rb:31:in `block in as_json': undefined method `section_hash' for #<RspecApiDocumentation::Writers::AppendJsonIndex:0x00007f8eed051198> (NoMethodError)
```

I noticed that there is a `JsonIndex` and `JSONIndex` class.  Looks like when using the `append_json` config, it's using the `JsonIndex` class, which is missing a `section_hash` method.  Seems fairly straightforward to implement and match the interface of the `JSONIndex` class.

Hope this helps address https://github.com/zipmark/rspec_api_documentation/issues/355#issuecomment-432302947