### PR TITLE
Skip empty schema generation when there are no fields

### DIFF
--- a/features/open_api.feature
+++ b/features/open_api.feature
@@ -342,9 +342,6 @@ Feature: Generate Open API Specification from test examples
               "200": {
                 "description": "List all instructions",
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                  }
                 },
                 "headers": {
                   "Content-Type": {
@@ -460,9 +457,6 @@ Feature: Generate Open API Specification from test examples
               "200": {
                 "description": "Getting a list of orders",
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                  }
                 },
                 "headers": {
                   "Content-Type": {
@@ -567,9 +561,6 @@ Feature: Generate Open API Specification from test examples
               "201": {
                 "description": "Creating an order",
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                  }
                 },
                 "headers": {
                   "Content-Type": {
@@ -623,9 +614,6 @@ Feature: Generate Open API Specification from test examples
               "200": {
                 "description": "Getting a specific order",
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                  }
                 },
                 "headers": {
                   "Content-Type": {
@@ -711,9 +699,6 @@ Feature: Generate Open API Specification from test examples
               "200": {
                 "description": "Update an order",
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                  }
                 },
                 "headers": {
                   "Content-Type": {
@@ -731,9 +716,6 @@ Feature: Generate Open API Specification from test examples
               "400": {
                 "description": "Invalid request",
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                  }
                 },
                 "headers": {
                   "Content-Type": {
@@ -778,9 +760,6 @@ Feature: Generate Open API Specification from test examples
               "200": {
                 "description": "Deleting an order",
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                  }
                 },
                 "headers": {
                   "Content-Type": {

--- a/lib/rspec_api_documentation/writers/open_api_writer.rb
+++ b/lib/rspec_api_documentation/writers/open_api_writer.rb
@@ -126,6 +126,8 @@ module RspecApiDocumentation
       end
 
       def extract_schema(fields)
+        return if fields.empty?
+        
         schema = {type: 'object', properties: {}}
 
         fields.each do |field|


### PR DESCRIPTION
If you're using open_api to generate swagger documentation before this change when you have an empty response body it would generate like this:
![image](https://user-images.githubusercontent.com/22180873/53967446-043f1c00-40d4-11e9-8b09-c6c7c8f8019d.png)

Now you'll have this:
![image](https://user-images.githubusercontent.com/22180873/53967491-17ea8280-40d4-11e9-961b-2dd9e272a69c.png)
Much cleanier