### PR TITLE
Fix Open API: add format setting for parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ This [format](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/
     - `maximum: <integer>`. Will setup lower limit for your parameter.
     - `enum: [<value>, <value>, ..]`. Will provide a pre-defined list of possible values for your parameter.
     - `type: [:file, :array, :object, :boolean, :integer, :number, :string]`. Will set a type for the parameter. Most of the type you don't need to provide this option manually. We extract types from values automatically.
-
+    - `format: <value>`. Will set a format of the parameter. ([Read more here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types))
 
 You also can provide a configuration file in YAML or JSON format with some manual configs. 
 The file should be placed in `configurations_dir` folder with the name `open_api.yml` or `open_api.json`. 

--- a/lib/rspec_api_documentation/open_api/parameter.rb
+++ b/lib/rspec_api_documentation/open_api/parameter.rb
@@ -11,6 +11,7 @@ module RspecApiDocumentation
       add_setting :required, :default => lambda { |parameter| parameter.in.to_s == 'path' ? true : false }
       add_setting :schema
       add_setting :type
+      add_setting :format
       add_setting :items
       add_setting :default
       add_setting :minimum

--- a/lib/rspec_api_documentation/writers/open_api_writer.rb
+++ b/lib/rspec_api_documentation/writers/open_api_writer.rb
@@ -172,6 +172,7 @@ module RspecApiDocumentation
           description:  opts[:description],
           required:     opts[:required],
           type:         opts[:type] || OpenApi::Helper.extract_type(opts[:value]),
+          format:       opts[:format],
           value:        opts[:value],
           with_example: opts[:with_example],
           default:      opts[:default],


### PR DESCRIPTION
In Swagger 2.0 for parameter primitive types, we can also set `format` attribute ([more info here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types)). For example type `string` could be with format `uuid`.

![image](https://user-images.githubusercontent.com/1286444/55332231-45d5a380-5495-11e9-8b79-eed4f3377d90.png)
