### PR TITLE
Fix Open Api: issue with multiple required fields

### DIFF
--- a/features/open_api.feature
+++ b/features/open_api.feature
@@ -192,7 +192,7 @@ Feature: Generate Open API Specification from test examples
 
           parameter :name, 'The order name', required: true, scope: :data, with_example: true
           parameter :amount, required: false, scope: :data, with_example: true
-          parameter :description, 'The order description', required: false, scope: :data, with_example: true
+          parameter :description, 'The order description', required: true, scope: :data, with_example: true
 
           header "Content-Type", "application/json"
 
@@ -700,7 +700,8 @@ Feature: Generate Open API Specification from test examples
                         }
                       },
                       "required": [
-                        "name"
+                        "name",
+                        "description"
                       ]
                     }
                   }

--- a/lib/rspec_api_documentation/writers/open_api_writer.rb
+++ b/lib/rspec_api_documentation/writers/open_api_writer.rb
@@ -149,7 +149,10 @@ module RspecApiDocumentation
             opts.each { |k, v| current[:properties][field[:name]][k] = v if v }
           end
 
-          current[:required] ||= [] << field[:name] if field[:required]
+          if field[:required]
+            current[:required] ||= []
+            current[:required] << field[:name]
+          end
         end
 
         OpenApi::Schema.new(schema)


### PR DESCRIPTION
Issue #429 
When multiple required fields were set, only one of them would show on the Open Api schema.
The `required` list would only be populated by the first required value.
This PR changes it so that multiple required values are able to be set on the schema

before:
```ruby
fields.each do |field|
#...
  current[:required] ||= [] << field[:name] if field[:required]
end
```

after:
```ruby
fields.each do |field|
#... 
  if field[:required]
    current[:required] ||= []
    current[:required] << field[:name]
  end
end
```