### PR TITLE
Make HttpTestClient HTTP compatible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     gherkin (3.2.0)
-    hashdiff (0.2.3)
+    hashdiff (1.0.0)
     httpclient (2.7.1)
     i18n (0.7.0)
     inch (0.8.0)
@@ -109,7 +109,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -127,10 +127,10 @@ GEM
     tins (1.16.3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    webmock (1.22.6)
+    webmock (3.6.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.9.15)
@@ -153,8 +153,8 @@ DEPENDENCIES
   rspec_api_documentation!
   sinatra (~> 1.4, >= 1.4.4)
   thin (~> 1.6, >= 1.6.3)
-  webmock (~> 1.7)
+  webmock (~> 3.6)
   yard (>= 0.9.11)
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/lib/rspec_api_documentation/curl.rb
+++ b/lib/rspec_api_documentation/curl.rb
@@ -5,9 +5,9 @@ module RspecApiDocumentation
   class Curl < Struct.new(:method, :path, :data, :headers)
     attr_accessor :host
 
-    def output(config_host, config_headers_to_filer = nil)
+    def output(config_host, config_headers_to_filter = nil)
       self.host = config_host
-      @config_headers_to_filer = Array(config_headers_to_filer)
+      @config_headers_to_filter = Array(config_headers_to_filter)
       send(method.downcase)
     end
 
@@ -79,9 +79,9 @@ module RspecApiDocumentation
     end
 
     def filter_headers(headers)
-      if !@config_headers_to_filer.empty?
+      if !@config_headers_to_filter.empty?
         headers.reject do |header|
-          @config_headers_to_filer.map(&:downcase).include?(format_header(header).downcase)
+          @config_headers_to_filter.map(&:downcase).include?(format_header(header).downcase)
         end
       else
         headers

--- a/lib/rspec_api_documentation/http_test_client.rb
+++ b/lib/rspec_api_documentation/http_test_client.rb
@@ -30,7 +30,7 @@ module RspecApiDocumentation
     LastRequest = Struct.new(:url, :method, :request_headers, :body)
 
     def request_headers
-      env_to_headers(last_request.request_headers)
+      last_request.request_headers
     end
 
     def response_headers
@@ -50,11 +50,11 @@ module RspecApiDocumentation
     end
 
     def request_content_type
-      last_request.request_headers["CONTENT_TYPE"]
+      last_request.request_headers["Content-Type"]
     end
 
     def response_content_type
-      last_response.request_headers["CONTENT_TYPE"]
+      last_response.request_headers["Content-Type"]
     end
 
     def do_request(method, path, params, request_headers)
@@ -70,10 +70,6 @@ module RspecApiDocumentation
     end
 
     protected
-
-    def headers(*args)
-      headers_to_env(super)
-    end
 
     def handle_multipart_body(request_headers, request_body)
       parsed_parameters = Rack::Request.new({

--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 10.1"
   s.add_development_dependency "rack-test", "~> 0.6.2"
   s.add_development_dependency "rack-oauth2", "~> 1.2.2", ">= 1.0.7"
-  s.add_development_dependency "webmock", "~> 1.7"
+  s.add_development_dependency "webmock", "~> 3.6"
   s.add_development_dependency "rspec-its", "~> 1.0"
   s.add_development_dependency "faraday", "~> 0.9", ">= 0.9.0"
   s.add_development_dependency "thin", "~> 1.6", ">= 1.6.3"

--- a/spec/http_test_client_spec.rb
+++ b/spec/http_test_client_spec.rb
@@ -65,8 +65,10 @@ describe RspecApiDocumentation::HttpTestClient do
       test_client.get "/", {}, { "Accept" => "application/json", "Content-Type" => "application/json", "User-Id" => "1" }
     end
 
+    let(:request_headers) { test_client.request_headers }
+
     it "should contain all the headers" do
-      expect(test_client.request_headers).to eq({
+      expect(request_headers).to include({
         "Accept" => "application/json",
         "Content-Type" => "application/json",
         "User-Id" => "1"
@@ -110,7 +112,7 @@ describe RspecApiDocumentation::HttpTestClient do
         expect(metadata[:response_headers]['Content-Type']).to match(/application\/json/)
         expect(metadata[:response_headers]['Content-Length']).to eq('17')
         expect(metadata[:response_content_type]).to match(/application\/json/)
-        expect(metadata[:curl]).to eq(RspecApiDocumentation::Curl.new("POST", "/greet?query=test+query", post_data, {"Content-Type" => "application/json;charset=utf-8", "X-Custom-Header" => "custom header value"}))
+        expect(metadata[:curl].output('http://localhost', 'User-Agent')).to eql(RspecApiDocumentation::Curl.new("POST", "/greet?query=test+query", post_data, {"Content-Type" => "application/json;charset=utf-8", "X-Custom-Header" => "custom header value"}).output('http://localhost', 'User-Agent'))
       end
 
       context "when post data is not json" do


### PR DESCRIPTION
HttpTestClient operates via HTTP. So it must send and receive [HTTP Headers](https://tools.ietf.org/html/rfc7230#section-3.2) not CGI Meta-Variables