### PR TITLE
Add comment about response_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ RspecApiDocumentation.configure do |config|
   config.html_embedded_css_file = nil
 
   # Removes the DSL method `status`, this is required if you have a parameter named status
+  # In this case you can assert response status with `expect(response_status).to eq 200`
   config.disable_dsl_status!
 
   # Removes the DSL method `method`, this is required if you have a parameter named method


### PR DESCRIPTION
When we use `config.disable_dsl_status!` than we can not `expect(status).to eq 200` but we can `expect(status_code).to_eq 200`
#329