### PR TITLE
Define a silent API formatter that will output nothing to the console

### DIFF
--- a/lib/rspec_api_documentation/silent_api_formatter.rb
+++ b/lib/rspec_api_documentation/silent_api_formatter.rb
@@ -1,0 +1,23 @@
+require 'rspec/core/formatters/base_formatter'
+
+module RspecApiDocumentation
+  class SilentApiFormatter < RSpec::Core::Formatters::BaseFormatter
+    RSpec::Core::Formatters.register self, :example_passed, :stop
+
+    def start(notification)
+      super
+
+      RspecApiDocumentation.documentations.each(&:clear_docs)
+    end
+
+    def example_passed(notification)
+      RspecApiDocumentation.documentations.each do |documentation|
+        documentation.document_example(example_notification.example)
+      end
+    end
+
+    def stop(notification)
+      RspecApiDocumentation.documentations.each(&:write)
+    end
+  end
+end


### PR DESCRIPTION
In our CI build process, so far, we are running the following commands (simplified):

```sh
$ bundle exec rspec \
  --format progress \
  --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/rspec.xml

$ bundle exec rake api:docs:generate
```

The first command runs RSpec on all our specs with a double output:
- dots to display progress in the console
- JUnit XML format to provide test reports to CircleCI

The second command run a Rake task based on rspec_api_documentation's [_Rake Task_ documentation](https://github.com/zipmark/rspec_api_documentation#rake-task):
```rb
RSpec::Core::RakeTask.new("api:docs:generate") do |t|
  ENV["RACK_ENV"] = ENV["RAILS_ENV"] = "test"
  t.pattern = [
    "spec/requests/api/**/*_spec.rb",
    "spec/requests/docs/**/*_spec.rb"
  ]
  t.rspec_opts = [
    "--format RspecApiDocumentation::ApiFormatter",
    "--order default"
  ]
end
```

The result is that we run some specs twice, just in order to generate API documentation. This generates a cost as API doc generation takes, by itself, a few minutes.

I realized quickly that it is possible for us to do this:

```sh
$ bundle exec rspec \
  --format progress \
  --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/rspec.xml \
  --format RspecApiDocumentation::ApiFormatter
```

This command runs all specs, and for RspecApiDocumentation spec, it will also generate the documentation, preventing us to run some specs twice, and allowing us to save some time.

Unfortunately, the `RspecApiDocumentation::ApiFormatter` formatter outputs too much and ends up polluting our CI output.
This PR is offering a solution to our problem: a silent API formatter that does not output anything to the console.