### PR TITLE
Allow response_body_formatter config to format "binary" responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ RspecApiDocumentation.configure do |config|
   # Change how the response body is formatted by default
   # Is proc that will be called with the response_content_type & response_body
   # by default, a response body that is likely to be binary is replaced with the string
-  # "[binary data]" and response_content_type of `application/json` are pretty formated.
+  # "[binary data]" regardless of the media type.  Otherwise, a response_content_type of `application/json` is pretty formatted.
   config.response_body_formatter = Proc.new { |response_content_type, response_body| response_body }
 
   # Change the embedded style for HTML output. This file will not be processed by

--- a/README.md
+++ b/README.md
@@ -252,7 +252,8 @@ RspecApiDocumentation.configure do |config|
 
   # Change how the response body is formatted by default
   # Is proc that will be called with the response_content_type & response_body
-  # by default response_content_type of `application/json` are pretty formated.
+  # by default, a response body that is likely to be binary is replaced with the string
+  # "[binary data]" and response_content_type of `application/json` are pretty formated.
   config.response_body_formatter = Proc.new { |response_content_type, response_body| response_body }
 
   # Change the embedded style for HTML output. This file will not be processed by

--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -87,12 +87,9 @@ module RspecApiDocumentation
 
     def record_response_body(response_content_type, response_body)
       return nil if response_body.empty?
-      if response_body.encoding == Encoding::ASCII_8BIT
-        "[binary data]"
-      else
-        formatter = RspecApiDocumentation.configuration.response_body_formatter
-        return formatter.call(response_content_type, response_body)
-      end
+
+      formatter = RspecApiDocumentation.configuration.response_body_formatter
+      formatter.call(response_content_type, response_body)
     end
 
     def clean_out_uploaded_data(params, request_body)

--- a/lib/rspec_api_documentation/configuration.rb
+++ b/lib/rspec_api_documentation/configuration.rb
@@ -118,7 +118,9 @@ module RspecApiDocumentation
     # See RspecApiDocumentation::DSL::Endpoint#do_request
     add_setting :response_body_formatter, default: Proc.new { |_, _|
       Proc.new do |content_type, response_body|
-        if content_type =~ /application\/.*json/
+        if response_body.encoding == Encoding::ASCII_8BIT
+          "[binary data]"
+        elsif content_type =~ /application\/.*json/
           JSON.pretty_generate(JSON.parse(response_body))
         else
           response_body


### PR DESCRIPTION
Following this issue on Rack's repository: [Fix incorrect MockResponse#body String encoding](https://github.com/rack/rack/pull/1486), it looks like we can expect, from now on, that Rack's `response_body` encoding will be `Encoding::ASCII_8BIT`:

> I think the response body should probably always be ASCII-8BIT. Rack can't really know anything about the encoding of the bytes that users want to send. At the end of the day, it's just bytes written to the socket, and I don't think Rack should have any opinion about the encoding the user sends.

Therefore, `rspec_api_documentation` cannot rely on `response_body.encoding` to determine whether the response is binary data or not. This line becomes incorrect:

https://github.com/zipmark/rspec_api_documentation/blob/81e5c563ce6787f143cf775c64e2bd08c35d3585/lib/rspec_api_documentation/client_base.rb#L90-L91

The real fix would be to figure out a better way to define whether a string is binary or not, but I believe this is a bit outside the scope of my knowledge.

In this PR, I'm focusing on giving any application using the `rspec_api_documentation` gem the choice on how to process the response_body, and particularly on how to detect binary data, while not altering `rspec_api_documentation`'s default behaviour.

As an additional benefit, this change would allow an application to display friendlier responses in its documentation for some binary types.

For example, PNG data:

```rb
config.response_body_formatter =
  Proc.new do |content_type, response_body|
    # http://www.libpng.org/pub/png/spec/1.2/PNG-Rationale.html#R.PNG-file-signature
    if response_body[0,8] == "\x89PNG\r\n\u001A\n"
      "<img src=\"data:image/png;base64,#{Base64.strict_encode64(response_body)}\" />"
    elsif content_type =~ /application\/.*json/
      JSON.pretty_generate(JSON.parse(response_body))
    else
      response_body
    end
  end
```