### PR TITLE
Remove dev dependency to Thin

### DIFF
--- a/rspec_api_documentation.gemspec
+++ b/rspec_api_documentation.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "webmock", "~> 1.22.6"
   s.add_development_dependency "rspec-its", "~> 1.2.0"
   s.add_development_dependency "faraday", "~> 0.9.2"
-  s.add_development_dependency "thin", "~> 1.6.4"
   s.add_development_dependency "nokogiri", "~> 1.8.4"
   s.add_development_dependency "yard", "~> 0.9.15"
   s.add_development_dependency "inch", "~> 0.8.0"

--- a/spec/http_test_client_spec.rb
+++ b/spec/http_test_client_spec.rb
@@ -9,13 +9,6 @@ require 'support/stub_app'
 describe RspecApiDocumentation::HttpTestClient do
   before(:all) do
     WebMock.allow_net_connect!
-
-    Capybara.server do |app, port|
-      require 'rack/handler/thin'
-      Thin::Logging.silent = true
-      Rack::Handler::Thin.run(app, :Port => port)
-    end
-
     server = Capybara::Server.new(StubApp.new, 8888)
     server.boot
   end


### PR DESCRIPTION
This change is part of preliminary efforts at attempting to refresh
the Continuous Integration setup, by supporting recent Ruby versions and
updating dependencies.

To be honest, I don't know what benefits the Thin server brings to the table.
I tried digging in the code, but the commit that introduced it does not
tell me much: cdeea8b.

What I know however is that I have troubles running the specs locally,
getting a timeout on this line:

https://github.com/zipmark/rspec_api_documentation/blob/560c3bdc7bd5581e7c223334390221ecfc910be8/spec/http_test_client_spec.rb#L16

However, letting Capybara handle its server details, as shown in this PR,
does not seem to have any negative impact (spec is still green, and fairly fast).