### PR TITLE
Remove Gemnasium links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/zipmark/rspec_api_documentation.svg?branch=master)](https://travis-ci.org/zipmark/rspec_api_documentation)
-[![Dependency Status](https://gemnasium.com/badges/github.com/zipmark/rspec_api_documentation.svg)](https://gemnasium.com/github.com/zipmark/rspec_api_documentation)
 [![Code Climate](https://codeclimate.com/github/zipmark/rspec_api_documentation/badges/gpa.svg)](https://codeclimate.com/github/zipmark/rspec_api_documentation)
 [![Inline docs](https://inch-ci.org/github/zipmark/rspec_api_documentation.svg?branch=master)](https://inch-ci.org/github/zipmark/rspec_api_documentation)
 [![Gem Version](https://badge.fury.io/rb/rspec_api_documentation.svg)](https://badge.fury.io/rb/rspec_api_documentation)

--- a/features/readme.md
+++ b/features/readme.md
@@ -1,5 +1,4 @@
 [![Travis status](https://secure.travis-ci.org/zipmark/rspec_api_documentation.png)](https://secure.travis-ci.org/zipmark/rspec_api_documentation)
-[![Gemnasium status](https://gemnasium.com/zipmark/rspec_api_documentation.png)](https://gemnasium.com/zipmark/rspec_api_documentation)
 
 http://github.com/zipmark/rspec_api_documentation
 


### PR DESCRIPTION
> ### Why is Gemnasium.com closed?
> Gemnasium was acquired by GitLab in January 2018. Since May 15, 2018, the services provided by Gemnasium are no longer available.

[Source.](https://docs.gitlab.com/ee/user/project/import/gemnasium.html#why-is-gemnasiumcom-closed)