### PR TITLE
Remove deprecated key in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 rvm:
   - 2.1.8
   - 2.2.4


### PR DESCRIPTION
> ⚠️ `root`: deprecated key `sudo` (The key \`sudo\` has no effect anymore.)

![image](https://user-images.githubusercontent.com/816901/94944513-53e60380-0514-11eb-85bc-97ee43b3e51d.png)
