### PR TITLE
Fix (open api writer): Allow to use same parameter name in different scopes

### DIFF
--- a/features/open_api.feature
+++ b/features/open_api.feature
@@ -193,6 +193,8 @@ Feature: Generate Open API Specification from test examples
           parameter :name, 'The order name', required: true, scope: :data, with_example: true
           parameter :amount, required: false, scope: :data, with_example: true
           parameter :description, 'The order description', required: true, scope: :data, with_example: true
+          parameter :address, 'The seller address', scope: [:data, :seller]
+          parameter :address, 'The buyer address', scope: [:data, :buyer]
 
           header "Content-Type", "application/json"
 
@@ -697,6 +699,24 @@ Feature: Generate Open API Specification from test examples
                           "type": "string",
                           "example": "fast order",
                           "description": "The order description"
+                        },
+                        "seller": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "The seller address"
+                            }
+                          }
+                        },
+                        "buyer": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "string",
+                              "description": "The buyer address"
+                            }
+                          }
                         }
                       },
                       "required": [

--- a/lib/rspec_api_documentation/writers/open_api_writer.rb
+++ b/lib/rspec_api_documentation/writers/open_api_writer.rb
@@ -159,7 +159,7 @@ module RspecApiDocumentation
       end
 
       def extract_parameters(example)
-        parameters = example.extended_parameters.uniq { |parameter| parameter[:name] }
+        parameters = example.extended_parameters.uniq { |parameter| [parameter[:name], parameter[:scope]] }
 
         extract_known_parameters(parameters.select { |p| !p[:in].nil? }) +
           extract_unknown_parameters(example, parameters.select { |p| p[:in].nil? })


### PR DESCRIPTION
I faced with a problem that I can't use the same parameter name in different scopes.
For example
```ruby
parameter :name, 'Player 1 name', scope: [:data, :player1]
parameter :name, 'Player 2 name', scope: [:data, :player2]
```
gives you only the first parameter in the result open api json.

This PR fixes this issue.