### PR TITLE
Warning about --api flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,3 +1036,7 @@ For an example on uploading a file see `examples/spec/acceptance/upload_spec.rb`
 - rspec_api_documentation relies on a variable `client` to be the test client. If you define your own `client` please configure rspec_api_documentation to use another one, see Configuration above.
 - We make heavy use of RSpec metadata, you can actually use the entire gem without the DSL if you hand write the metadata.
 - You must use `response_body`, `status`, `response_content_type`, etc. to access data from the last response. You will not be able to use `response.body` or `response.status` as the response object will not be created.
+
+## --api flag
+
+`rspec_api_documentation` is using assets, but `--api` flag prevents to add asset pipeline to project as default. If Ruby on Rails project is started by using `--api` flag, it is necessary to add `sprockets` gem to gemfile.


### PR DESCRIPTION
I added `rspec_api_documentation` gem to my project, but it was raising an error about assets when I tried to create documents. I fixed this issue by adding `sprockets` gem to gemfile. I initialized my project with `--api` flag, so `sprockets` is not added automatically. 

This PR provides a solution for this error.