### PR TITLE
Only call value method if it has zero arity

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint/set_param.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint/set_param.rb
@@ -57,7 +57,7 @@ module RspecApiDocumentation
             custom_method_name if example_group.respond_to?(custom_method_name)
           elsif scoped_key && example_group.respond_to?(scoped_key)
             scoped_key
-          elsif key && example_group.respond_to?(key)
+          elsif key && example_group.respond_to?(key) && example_group.public_method(key).arity.zero?
             key
           elsif key && set_value
             key


### PR DESCRIPTION
This PR fixes a compatibility problem with Rails when the user specifies `parameter` with the same name as `ActionDispatch::Integration::RequestHelpers` methods.

This came up in our application because we are accepting a parameter name `options`, and when upgrading to Rails 6.1 we starting to get this error:

```
ArgumentError:
  wrong number of arguments (given 0, expected 1)
# [GEM_HOME]/actionpack-6.1.3.2/lib/action_dispatch/testing/integration.rb:51:in `options'
# [GEM_HOME]/actionpack-6.1.3.2/lib/action_dispatch/testing/integration.rb:429:in `public_send'
# [GEM_HOME]/actionpack-6.1.3.2/lib/action_dispatch/testing/integration.rb:429:in `method_missing'
# [BUNDLER_GEM_HOME]/rspec_api_documentation-d3892cc73884/lib/rspec_api_documentation/dsl/endpoint/set_param.rb:20:in `value'
# [BUNDLER_GEM_HOME]/rspec_api_documentation-d3892cc73884/lib/rspec_api_documentation/dsl/endpoint/params.rb:29:in `block in extended'
# [BUNDLER_GEM_HOME]/rspec_api_documentation-d3892cc73884/lib/rspec_api_documentation/dsl/endpoint/params.rb:27:in `map'
# [BUNDLER_GEM_HOME]/rspec_api_documentation-d3892cc73884/lib/rspec_api_documentation/dsl/endpoint/params.rb:27:in `extended'
# [BUNDLER_GEM_HOME]/rspec_api_documentation-d3892cc73884/lib/rspec_api_documentation/dsl/endpoint.rb:107:in `extended_parameters'
# [BUNDLER_GEM_HOME]/rspec_api_documentation-d3892cc73884/lib/rspec_api_documentation/dsl/endpoint.rb:41:in `do_request'

```

After some investigation, it seems like Rails 6.1 has added `options` method to `ActionDispatch::Integration::RequestHelpers` which get included to Request specs:

https://github.com/rails/rails/blob/v6.1.1/actionpack/lib/action_dispatch/testing/integration.rb#L49-L53

```ruby
      # Performs an OPTIONS request with the given parameters. See ActionDispatch::Integration::Session#process
      # for more details.
      def options(path, **args)
        process(:options, path, **args)
      end
```

Therefore when rspec_api_documentation tries to call `options` method to get the value, it accidentally calling this helper method from Rails instead and resulting in `ArgumentError`.

Since it's a bit tricky to detect where the method was defined, I propose a solution in this PR in which we just check if the value method has an arity of zero (i.e. doesn't take any argument) before calling it. This way, `rspec_api_documentation` will still automatically call a value method if it's defined or overridden by the user.