### PR TITLE
Allow to pass metadata to example_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,8 +528,8 @@ resource "Account" do
       expect(status).to eq 404
     end
 
-    # With example_request, you can't change the :document
-    example_request "Get a list on page 3", :page => 3 do
+    # With example_request, you can change the :document via metadata
+    example_request "Get a list on page 3", :page => 3, :metadata => {:document => false} do
       expect(status).to eq 404
     end
   end
@@ -655,6 +655,13 @@ resource "Orders" do
       # make assertions
     end
   end
+end
+```
+
+For passing metadata to example_request you can use param named `:metadata`
+```ruby
+example_request "Creating an order", :name => "Other name", metadata: {document: :private} do
+  # make assertions
 end
 ```
 

--- a/lib/rspec_api_documentation/dsl/endpoint.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint.rb
@@ -15,7 +15,10 @@ module RspecApiDocumentation::DSL
 
     module ClassMethods
       def example_request(description, params = {}, &block)
-        example description, :caller => block.send(:caller) do
+        metadata = params.fetch(:metadata, {})
+        example_params = {caller: block.send(:caller)}.merge!(metadata)
+
+        example description, example_params do
           do_request(params)
           instance_eval &block if block_given?
         end


### PR DESCRIPTION
@davidstosik @jakehow Hi. What do you think to allow pass metadata options to example_request? 