### PR TITLE
Prevent In-Place Modification of Parameter Scopes.

### DIFF
--- a/lib/rspec_api_documentation/dsl/endpoint/params.rb
+++ b/lib/rspec_api_documentation/dsl/endpoint/params.rb
@@ -29,15 +29,18 @@ module RspecApiDocumentation
             p[:value] = SetParam.new(self, nil, p).value
             unless p[:value]
               cur = extra_params
-              [*p[:scope]].each { |scope| cur = cur && (cur[scope.to_sym] || cur[scope.to_s]) }
 
-              # When the current parameter is an array of objects, we use the
-              # first one for the value and add a scope indicator. The
-              # resulting parameter name looks like +props[pictures][][id]+
-              # this.
-              if cur.is_a?(Array) && cur.first.is_a?(Hash)
-                cur = cur.first
-                p[:scope] << ''
+              [*p[:scope]].each do |scope|
+                cur = cur && (cur[scope.to_sym] || cur[scope.to_s])
+
+                # When the current parameter is an array of objects, we use the
+                # first one for the value and add a scope indicator. The
+                # resulting parameter name looks like +props[pictures][][id]+
+                # this.
+                if cur.is_a?(Array) && cur.first.is_a?(Hash)
+                  cur = cur.first
+                  p[:scope] << ''
+                end
               end
 
               p[:value] = cur && (cur[p[:name].to_s] || cur[p[:name].to_sym])
@@ -49,7 +52,6 @@ module RspecApiDocumentation
       private
 
         attr_reader :extra_params
-
       end
     end
   end


### PR DESCRIPTION
## Fixes:
```
TypeError:
 no implicit conversion of Symbol into Integer
```

## Cause:
Original (instead of cloned) scope info was modified for each parameter value, resulting in duplicate indicators being inserted into the scope.
Also, cases with multiple levels of nested arrays were not handled.

e.g.
```ruby
{
  foo_attributes: [
    id: 1,
    bar_attributes: [
      id: 2
    ]
  ]
}
```