### PR TITLE
Add :json option back to config.format

### DIFF
--- a/example/spec/acceptance_helper.rb
+++ b/example/spec/acceptance_helper.rb
@@ -3,7 +3,7 @@ require 'rspec_api_documentation'
 require 'rspec_api_documentation/dsl'
 
 RspecApiDocumentation.configure do |config|
-  config.format = [:open_api, :html]
+  config.format = [:json, :open_api, :html]
   config.curl_host = 'http://localhost:3000'
   config.api_name = "Example App API"
   config.api_explanation = "API Example Description"


### PR DESCRIPTION
in `example/spec/acceptance_helper.rb`
to make raddocs for the example project work again

There was an exception on `/docs` route:
```
Errno::ENOENT at /docs/
No such file or directory @ rb_sysopen - doc/api/index.json
```
After adding the `:json` format back and running `rake docs:generate`, `/docs` started working again