### PR TITLE
allow-user-to-pass-env-variables-when-generating-docs

### DIFF
--- a/lib/rspec_api_documentation/writers/open_api_writer.rb
+++ b/lib/rspec_api_documentation/writers/open_api_writer.rb
@@ -18,7 +18,7 @@ module RspecApiDocumentation
 
       def load_config
         return JSON.parse(File.read("#{configurations_dir}/open_api.json")) if File.exist?("#{configurations_dir}/open_api.json")
-        YAML.load_file("#{configurations_dir}/open_api.yml") if File.exist?("#{configurations_dir}/open_api.yml")
+        YAML.load(ERB.new(File.read("#{configurations_dir}/open_api.yml")).result) if File.exist?("#{configurations_dir}/open_api.yml")
       end
     end
 


### PR DESCRIPTION
Why
This is to allow users to use environment variables in their `open_api.yaml` file. Like so:
```
swagger: '2.0'
info:
  title: My Api
  description: About my api
  version: "1.0.0"
host: <%= ENV.fetch('host_name') %>
```
They could then call the generate command like:
```
host_name=env_specific_host.com rake docs:generate
```
This way someone can generate multiple different swaggers with different environemnts