### PR TITLE
Add parameter enums and defaults to HTML example

### DIFF
--- a/lib/rspec_api_documentation/example.rb
+++ b/lib/rspec_api_documentation/example.rb
@@ -38,6 +38,14 @@ module RspecApiDocumentation
       respond_to?(:parameters) && parameters.present?
     end
 
+    def has_enum?
+      respond_to?(:parameters) && parameters.present? && parameters.any? { |i| i[:enum] }
+    end
+
+    def has_default?
+      respond_to?(:parameters) && parameters.present? && parameters.any? { |i| i[:default] }
+    end
+
     def has_attributes?
       respond_to?(:attributes) && attributes.present?
     end

--- a/templates/rspec_api_documentation/html_example.mustache
+++ b/templates/rspec_api_documentation/html_example.mustache
@@ -31,6 +31,12 @@
               <tr>
                 <th>Name</th>
                 <th>Description</th>
+                {{# has_enum? }}
+                  <th>Accepted values</th>
+                {{/ has_enum? }}
+                {{# has_default? }}
+                  <th>Default</th>
+                {{/ has_default? }}
               </tr>
             </thead>
             <tbody>
@@ -47,6 +53,12 @@
                 <td>
                   <span class="description">{{ description }}</span>
                 </td>
+                {{# has_enum? }}
+                  <td>{{ enum }}</td>
+                {{/ has_enum? }}
+                {{# has_default? }}
+                  <td>{{ default }}</td>
+                {{/ has_default? }}
               </tr>
               {{/ parameters }}
             </tbody>


### PR DESCRIPTION
Support to dispaly parameter enums and defaults in generated HTML docs.