### PR TITLE
Deal with nil rack.input with rack 3.1

### DIFF
--- a/lib/rspec_api_documentation/client_base.rb
+++ b/lib/rspec_api_documentation/client_base.rb
@@ -45,8 +45,8 @@ module RspecApiDocumentation
 
     def read_request_body
       input = last_request.env["rack.input"]
-      input.rewind
-      input.read
+      input&.rewind
+      input&.read || ""
     end
 
     def document_example(method, path)


### PR DESCRIPTION
After moving to rack 3.1.x, `last_request.env["rack.input"]` is returning nil on `get` requests. This will safely deal with that situation, replacing the return value with an empty string.