### PR TITLE
README: Drop CodeClimate broken badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Code Climate](https://codeclimate.com/github/zipmark/rspec_api_documentation/badges/gpa.svg)](https://codeclimate.com/github/zipmark/rspec_api_documentation)
 [![Inline docs](https://inch-ci.org/github/zipmark/rspec_api_documentation.svg?branch=master)](https://inch-ci.org/github/zipmark/rspec_api_documentation)
 [![Gem Version](https://badge.fury.io/rb/rspec_api_documentation.svg)](https://badge.fury.io/rb/rspec_api_documentation)
 


### PR DESCRIPTION
This PR removes a broken link and image to CodeClimate, a defunct service.